### PR TITLE
fix clipped "brighterscript" text

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,7 +4,7 @@
     ],
     "trailingComma": "none",
     "tabWidth": 4,
-    "endOfLine": "lf",
+    "endOfLine": "auto",
     "semi": true,
     "singleQuote": true,
     "bracketSameLine": true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint \"src/**/*.{astro,ts}\"",
-    "check-format": "prettier --config ./.prettierrc.json --check \"src/**/*.{astro,css,ts}\""
+    "check-format": "prettier --config ./.prettierrc.json --check \"src/**/*.{astro,css,ts}\"",
+    "format": "npm run check-format -- -w"
   },
   "dependencies": {
     "@astrojs/image": "^0.9.3",

--- a/src/components/landing/BrighterScriptTitle.astro
+++ b/src/components/landing/BrighterScriptTitle.astro
@@ -12,6 +12,7 @@ const { title } = Astro.props;
         font-style: normal;
         font-weight: 700;
         line-height: 70px;
+        padding-bottom: 10px;
 
         /* identical to box height, or 109% */
         text-align: center;


### PR DESCRIPTION
Fixes this issue. Before:
![image](https://user-images.githubusercontent.com/2544493/198045106-00ee3f1b-7aa0-4aa5-9420-00c4e0cb0fc4.png)

After:
![image](https://user-images.githubusercontent.com/2544493/198045182-6ead3239-ac1e-43c5-8969-2ceaad84cc49.png)
