### PR TITLE
Retain url on scroll

### DIFF
--- a/src/images.ts
+++ b/src/images.ts
@@ -1,7 +1,0 @@
-export const images = {
-    openInNew: {
-        src: '/images/icons/open-in-new-pink.svg',
-        alt: 'Download Visual Studio Code plugin icon'
-    },
-    logo: {}
-};

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,12 +59,12 @@ const { title } = Astro.props;
                 document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
                     anchor.addEventListener('click', function (e) {
                         e.preventDefault();
-
                         document
                             .querySelector(this.getAttribute('href'))
                             .scrollIntoView({
                                 behavior: 'smooth'
                             });
+                        history.pushState({}, '', this.href);
                     });
                 });
             });

--- a/src/layouts/landing/Hero.astro
+++ b/src/layouts/landing/Hero.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from '@astrojs/image/components';
 import GithubWhiteLogo from '../../components/landing/GithubWhiteLogo.astro';
 import HeroWhatsNew from '../../components/landing/HeroWhatsNew.astro';
 import NewsletterCTA from '../../components/landing/NewsletterCTA.astro';
@@ -57,7 +56,7 @@ import SlackWhiteLogo from '../../components/landing/SlackWhiteLogo.astro';
         <p class="w-max text-white text-2xl font-sans font-light">
             See our magic in action
         </p>
-        <Image
+        <img
             class="float-up-down"
             src="/images/icons/arrow-down.svg"
             alt="Icon arrow down"


### PR DESCRIPTION
Keep the hashtag when clicking on in-page hyperlinks before scrolling.