### PR TITLE
Fix whatsnew generator bug for latest tag scraping

### DIFF
--- a/scripts/create-whats-new.ts
+++ b/scripts/create-whats-new.ts
@@ -263,9 +263,9 @@ class Runner {
          *      2022-10-28 13:02:25 -0400  (tag: v0.60.4)
          */
         const execResult = await exec('git log --tags --simplify-by-decoration --pretty="format:%ci %d"', { cwd: project.dir });
-        //https://regex101.com/r/cGcKUj/2
+        //https://regex101.com/r/cGcKUj/3
         const releases = [
-            ...execResult.stdout.matchAll(/(\d+-\d+-\d+\s*(?:\d+:\d+:\d+(?:\s*[+-]?\d+))?).*?\(tag:[ \t]*(v.*?)\)/g)
+            ...execResult.stdout.matchAll(/(\d+-\d+-\d+\s*(?:\d+:\d+:\d+(?:\s*[+-]?\d+))?).*?\(.*\btag:[ \t]*(v.*?)[,)]/g)
         ].map(x => ({
             date: new Date(x[1]),
             version: x[2]


### PR DESCRIPTION
Fixes a bug in the whatsnew generator script that would miss the information in the target month sometimes. This was caused by our tag scraping regex not properly handling this pattern:

![image](https://user-images.githubusercontent.com/2544493/235451659-c5618f0c-919c-498d-a824-4db67e3d2ff6.png)

Fixed with this:
![image](https://user-images.githubusercontent.com/2544493/235451669-66d64fb6-e8d3-4567-b5b9-6e9633668c18.png)

