### PR TITLE
Fix whatsnew generator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,10 @@
     "typescript", // Enable .ts
   ],
   "cSpell.words": [
-    "oneline"
+    "oneline",
+    "bsconfig",
+    "iface",
+    "noproject",
+    "transpiling"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
   "eslint.validate": [
     "astro", // Enable .astro
     "typescript", // Enable .ts
+  ],
+  "cSpell.words": [
+    "oneline"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
         "@fontsource/material-icons": "^4.5.4",
         "@fontsource/poppins": "^4.5.10",
         "astro": "^1.4.6",
+        "fast-glob": "^3.3.2",
         "sharp": "^0.31.1",
         "tailwindcss": "^3.1.8"
       },
       "devDependencies": {
         "@types/chalk": "^2.2.0",
+        "@types/fs-extra": "^11.0.4",
         "@types/node": "^18.11.4",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
@@ -1496,6 +1498,16 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -1519,6 +1531,15 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
       "integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA=="
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.1",
@@ -4387,9 +4408,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -11954,6 +11975,16 @@
         "@types/estree": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/hast": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -11977,6 +12008,15 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
       "integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA=="
+    },
+    "@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/jsonwebtoken": {
       "version": "9.0.1",
@@ -13980,9 +14020,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "@fontsource/material-icons": "^4.5.4",
     "@fontsource/poppins": "^4.5.10",
     "astro": "^1.4.6",
+    "fast-glob": "^3.3.2",
     "sharp": "^0.31.1",
     "tailwindcss": "^3.1.8"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "^18.11.4",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/scripts/create-whats-new.ts
+++ b/scripts/create-whats-new.ts
@@ -245,21 +245,21 @@ class Runner {
 
         result.push(
             '',
-            '# Thank you',
-            `Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:`
+            '# Thank you\n',
+            `Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:`
         );
         for (const project of this.projects) {
             //skip projects that had no releases this month
             if (project.commits.length === 0) {
                 continue;
             }
-            result.push('', `Contributions to [${project.name}](${project.repositoryUrl}):`);
+            result.push('', `Contributions to [${project.name}](${project.repositoryUrl}):\n`);
             for (const [, commits] of this.groupCommitsByUser(project)) {
                 const { author } = commits[0];
-                result.push(` - [@${author.username} (${author.name})](${author.profileUrl})`);
+                result.push(`-   [@${author.username} (${author.name})](${author.profileUrl})`);
                 for (const commit of commits) {
                     result.push(
-                        '    - ' + (
+                        '    -   ' + (
                             commit.pullRequestId
                                 ? `${commit.message} ([PR #${commit.pullRequestId}](${project.repositoryUrl}/pull/${commit.pullRequestId}))`
                                 : `${commit.message} ([${commit.hash}](${project.repositoryUrl}/commit/${commit.hash}))`
@@ -293,15 +293,17 @@ class Runner {
      * Find all the releases for a given date range, including the leading and trailing releases that are outside the date range
      */
     private async getCommits(project: Project): Promise<Commit[]> {
-        this.log(project, `Finding releases between ${dayjs(this.startDate).format('YYYY-MM-DD')
-            } and ${dayjs(this.endDate).format('YYYY-MM-DD')} `);
+        this.log(project, `Finding releases between ${dayjs(this.startDate).format('YYYY-MM-DD')} and ${dayjs(this.endDate).format('YYYY-MM-DD')} `);
         /**
          * generates output like:
          *      2022-11-03 16:01:48 -0400  (tag: v0.60.5)
          *      2022-10-28 13:02:25 -0400  (tag: v0.60.4)
          */
+        //widen the dates by 2 days to overscan a bit (avoids weird UTC issues)
+        const startDateText = dayjs(this.startDate).subtract(2, 'days').format('YYYY-MM-DD');
+        const endDateText = dayjs(this.endDate).add(2, 'days').format('YYYY-MM-DD');
         const execResult = this.execSync(
-            `git log --tags --simplify-by-decoration --pretty="format:%ci %d" --since="${dayjs(this.startDate).format('YYYY-MM-DD')}" --until="${dayjs(this.endDate).format('YYYY-MM-DD')}"`,
+            `git log --tags --simplify-by-decoration --pretty="format:%ci %d" --since="${startDateText}" --until="${endDateText}"`,
             project
         );
         //https://regex101.com/r/cGcKUj/3

--- a/scripts/create-whats-new.ts
+++ b/scripts/create-whats-new.ts
@@ -335,7 +335,8 @@ class Runner {
         const commitMap = new Map<string, Commit>();
         for (const release of matchedReleases) {
             this.log(project, `finding commits for ${release.version}`);
-            for (const commit of this.getCommitsForReleaseVersion(project, release.version, release.previousRef)) {
+            const commits = this.getCommitsForReleaseVersion(project, release.version, release.previousRef);
+            for (const commit of commits) {
                 commitMap.set(commit.hash, commit);
             }
         }
@@ -412,21 +413,8 @@ class Runner {
             } as Commit;
             //sort by date descending
         }).sort((a, b) => b.date.getTime() - a.date.getTime());
-
-        // find the release that occurred right before the first release in this month
-        for (let i = 0; i < commits.length; i++) {
-            let commit = commits[i];
-
-            //this commit date is earlier than this month's start date, and it has a tag. we found it!
-            if (commit.date < this.startDate && commit.tag) {
-                const result = commits.slice(0, i);
-                return result;
-            }
-        }
-        //we didn't find a release...so assume ALL the commits were part of a release found within the date range
         return commits;
     }
-
 
     private async hydrateCommit(project: Project, commit: Commit) {
         const keys = [project.repositoryUrl, 'commits', commit.hash];
@@ -547,13 +535,6 @@ interface Commit {
      * The value of a tag on the commit (if it has one)
      */
     tag?: string;
-}
-
-interface Release {
-    date: Date;
-    version: string;
-    previousRef: string;
-    commits: Commit[];
 }
 
 interface RunnerOptions {

--- a/scripts/create-whats-new.ts
+++ b/scripts/create-whats-new.ts
@@ -516,8 +516,16 @@ class Runner {
             console.log(`Loading referenced commits from ${path.basename(file)}`);
 
             const contents = fsExtra.readFileSync(file).toString();
-            const md = contents.split(/#\s+Thank\s+you/g)?.[1] ?? '';
-            const lines = md.split(/\r?\n/g)
+
+            let lines = contents.split(/\r?\n/g);
+            //walk up from the bottom to find the final # Thank You section. throw away everything above
+            for (let i = lines.length - 1; i >= 0; i--) {
+                if (/^\s*#\s*Thank\s+you/g.test(lines[i])) {
+                    lines.splice(0, i);
+                    break;
+                }
+            }
+            lines = lines
                 .map(x => x.trim())
                 //remove empty lines
                 .filter(x => x !== '')

--- a/src/pages/whats-new/2023-01-January.md
+++ b/src/pages/whats-new/2023-01-January.md
@@ -3,20 +3,24 @@ date: January 2023
 summary: Complex debug protocol REPL expressions, SceneGraph Inspector improvements, callfunc validations, syntax highlighting, and more.
 layout: ../../layouts/WhatsNewPost.astro
 ---
+
 # Overview
+
 This month we made some great improvements to the debugging experience, such as support for [executing complex expressions in the REPL and watch panels](#allow-relative-rale-tracker-task-path), fixing that frustrating [infinite spin](#fix-infinite-spin-for-unloaded-vars) issue in the variables panel, and some nice new features in [SceneGraph Inspector](#scenegraph-inspector-improvements).
 
 When editing your projects, you will now see a new diagnostic whenever you use more than the [max callfunc arguments](#new-diagnostic-for-max-callfunc-arguments), and we've improved syntax highlighting for the [`continue for` and `continue while`](#syntax-highlighting-for-continue-for-and-continue-while) keywords.
 
 We also made a few [non-user-facing](#misc) changes to help RokuCommunity contributors work on the projects.
 
-
 # Debugging
+
 ## Allow relative RALE tracker task path
+
 The RALE tracker task path can now be a relative path, and supports replacement variables like `${workspaceFolder}`
- ![image](https://user-images.githubusercontent.com/2544493/221651842-93754a1e-6bbd-4d5a-b75f-da72b0fcfe58.png)
+![image](https://user-images.githubusercontent.com/2544493/221651842-93754a1e-6bbd-4d5a-b75f-da72b0fcfe58.png)
 
 ## Execute complex REPL expressions in the Run & Debug panel
+
 Now the Watch section of the Run & Debug panel supports complex REPL expressions when using Roku's new [debug protocol](https://developer.roku.com/en-ca/docs/developer-program/debugging/socket-based-debugger.md). This means you can now execute expressions like `doSomething()` or `"alpha" + chr(3)`.
 
 ![image](https://user-images.githubusercontent.com/29876959/223409615-49099453-cdad-4e9c-a8de-16e4030d78d2.png)
@@ -26,6 +30,7 @@ Now the Watch section of the Run & Debug panel supports complex REPL expressions
 ![image](https://user-images.githubusercontent.com/29876959/223410841-e3b97783-2e34-4fef-b7d5-4cdc138a5a48.png)
 
 ## Fix infinite spin for unloaded vars
+
 Fix a bug where the UI would spin forever when trying to load variables that no longer exist, and would then cause the rest of the debug session to become unresponsive. Now we show a useful error message instead.
 
 Before:
@@ -34,20 +39,22 @@ Before:
 After:
 ![image](https://user-images.githubusercontent.com/2544493/210621741-2a9cc1cd-4b65-4358-8c43-e244cacd0b80.png)
 
-
 ## Hide certain prefixed variables in the Debug panel
+
 Our debug adapters currently create variables like `vscodeLoopKey`, `vscodeLoopItem`, etc. These variables show up in the `Local variables` panel after the first step. We have established the prefix `__rokudebug__` for tool-generated variables and we will now filter variables that start with this prefix so they don't show in the the various Debug panels.
 
 If for some reason you need to see these variables, you can set `"showHiddenVariables": true` in your `launch.json`.
 
-
 ## Fix off-by-1 bug with threads over protocol
+
 We fixed a bug in the Debug Protocol where the wrong line numbers were being reported for the threads response. We had incorrectly assumed that the protocol reported 0-based line numbers, when in fact they are 1-based. This was largly not evident to the user because we had a few workarounds in place, but now we can directly trust the values coming from the device.
 
 ## Increased the timeout for debug protocol control
+
 For larger apps it takes longer than 5 seconds to finish parsing and compiling the app, which would cause the debug protocol to time out and terminate the debug session. In the short term we just doubled our internal timeout to 10 seconds, but ideally this would be configurable so that may eventually be implemented in a future release.
 
 ## SceneGraph Inspector improvements
+
 The SceneGraph Inspector has been enhanced with a new keypath syntax which should make it much easier to identify a specific node in the scene at a point in time. This is powered by some [better keypath logic](https://github.com/RokuCommunity/vscode-brightscript-language/pull/455) in RDB. You can see the new `keyPath` field in the screenshot below:
 
 ![image](https://user-images.githubusercontent.com/2544493/221642229-510a37ed-d37b-4c6c-ac6b-8d0380343a30.png)
@@ -55,12 +62,15 @@ The SceneGraph Inspector has been enhanced with a new keypath syntax which shoul
 We've also improved the reliability of the focus scrolling.
 
 # BrighterScript
+
 ## New diagnostic for max callfunc arguments
+
 An undocumented limitation of SceneGraph's `callfunc` functionality is that you cannot pass more than 5 arguments. Doing so would cause the call to silently fail, and sometimes even crash the application. [BrighterScript#765](https://github.com/RokuCommunity/brighterscript/pull/765) adds a diagnostic to flag these types of calls so you can detect them at compile time instead of at runtime.
 
 ![image](https://user-images.githubusercontent.com/29876959/223404690-cef9d4a3-884a-4088-a0b8-8bbc998b94cc.png)
 
 ## Syntax highlighting for `continue for` and `continue while`
+
 Syntax highlighting for the new `continue while` and `continue for` keywords was fixed in [v2.38.7](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2387---2023-01-24)
 
 **Before:**
@@ -78,7 +88,9 @@ We want to make sure changes to BrighterScript don't break the main projects tha
 We have also started running the test suites from the [rooibos](https://github.com/georgejecook/rooibos) and [maestro-roku-bsc-plugin](https://github.com/georgejecook/maestro-roku-bsc-plugin) projects.
 
 # Misc
+
 ## Improved extension development experience
+
 Historically, you'd need to manually launch watcher tasks for each RokuCommunity project that you were actively working on. As of [vscode-brightscript-language#456](https://github.com/RokuCommunity/vscode-brightscript-language/pull/456), we automatically find all RokuCommunity repositories cloned at the same level as vscode-brightscript-language, and launch a combined watcher task for all of them. This greatly simplifies the development experience, reducing confusion for community contributors.
 
 ## Fix Github action that creates .vsix files on PR changes
@@ -90,50 +102,57 @@ If you are a contributor to the [roku-debug](https://github.com/rokucommunity/ro
 The link to the instalation instructions was broken. Now we have updated it to open the correct page in our new website: [rokucommunity.github.io](https://rokucommunity.github.io/).
 
 # Thank you
-Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
- - [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
-    - Watch all dependency and configuration updates ([PR #460](https://github.com/RokuCommunity/vscode-brightscript-language/pull/460))
- - [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
-    - Allow relative injectRaleTrackerTask ([PR #462](https://github.com/RokuCommunity/vscode-brightscript-language/pull/462))
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - Fix rdb keypaths and focus scrolling ([PR #455](https://github.com/RokuCommunity/vscode-brightscript-language/pull/455))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - watch-all ([PR #456](https://github.com/RokuCommunity/vscode-brightscript-language/pull/456))
-    - Fix vsmarketplace badge ([b2153a3](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b2153a3))
-    - Use png instead of svg ([d1e3d29](https://github.com/RokuCommunity/vscode-brightscript-language/commit/d1e3d29))
-    - fix: continue keyword colorization ([PR #459](https://github.com/RokuCommunity/vscode-brightscript-language/pull/459))
-    - Fix dependency order in watch-all ([b7843a7](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b7843a7))
+
+-   [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
+    -   Watch all dependency and configuration updates ([PR #460](https://github.com/RokuCommunity/vscode-brightscript-language/pull/460))
+-   [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
+    -   Allow relative injectRaleTrackerTask ([PR #462](https://github.com/RokuCommunity/vscode-brightscript-language/pull/462))
+-   [@triwav (Brian Leighty)](https://github.com/triwav)
+    -   Fix rdb keypaths and focus scrolling ([PR #455](https://github.com/RokuCommunity/vscode-brightscript-language/pull/455))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   watch-all ([PR #456](https://github.com/RokuCommunity/vscode-brightscript-language/pull/456))
+    -   Fix vsmarketplace badge ([b2153a3](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b2153a3))
+    -   Use png instead of svg ([d1e3d29](https://github.com/RokuCommunity/vscode-brightscript-language/commit/d1e3d29))
+    -   fix: continue keyword colorization ([PR #459](https://github.com/RokuCommunity/vscode-brightscript-language/pull/459))
+    -   Fix dependency order in watch-all ([b7843a7](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b7843a7))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@iObject (Tyler Smith)](https://github.com/iObject)
-    - Add diagnostic for passing more than 5 arguments to a callFunc ([PR #765](https://github.com/RokuCommunity/brighterscript/pull/765))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix test-related-projects. Reenable rooibos ([PR #761](https://github.com/RokuCommunity/brighterscript/pull/761))
-    - Fixing issues before release 0.61.3 ([fd841a0](https://github.com/RokuCommunity/brighterscript/commit/fd841a0))
+
+-   [@iObject (Tyler Smith)](https://github.com/iObject)
+    -   Add diagnostic for passing more than 5 arguments to a callFunc ([PR #765](https://github.com/RokuCommunity/brighterscript/pull/765))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix test-related-projects. Reenable rooibos ([PR #761](https://github.com/RokuCommunity/brighterscript/pull/761))
+    -   Fixing issues before release 0.61.3 ([fd841a0](https://github.com/RokuCommunity/brighterscript/commit/fd841a0))
 
 Contributions to [logger](https://github.com/RokuCommunity/logger):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Update build.yml ([6b13d47](https://github.com/RokuCommunity/logger/commit/6b13d47))
-    - Fix audit issues ([0583c2b](https://github.com/RokuCommunity/logger/commit/0583c2b))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Update build.yml ([6b13d47](https://github.com/RokuCommunity/logger/commit/6b13d47))
+    -   Fix audit issues ([0583c2b](https://github.com/RokuCommunity/logger/commit/0583c2b))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@adellhk (adellhk)](https://github.com/adellhk)
-    - Update create-vsix.yml ([PR #126](https://github.com/RokuCommunity/roku-debug/pull/126))
- - [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
-    - Execute command for repl expressions ([PR #119](https://github.com/RokuCommunity/roku-debug/pull/119))
-    - Fix isAssignableExpression to correctly support dotted and indexed statements ([PR #128](https://github.com/RokuCommunity/roku-debug/pull/128))
-    - Hiding prefixed variables in the debug variable panel ([PR #127](https://github.com/RokuCommunity/roku-debug/pull/127))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix inifinite-spin for unloaded vars ([PR #120](https://github.com/RokuCommunity/roku-debug/pull/120))
-    - Fix off-by-1 bug with threads over protocol ([PR #132](https://github.com/RokuCommunity/roku-debug/pull/132))
-    - Increase the timeout for debug protocol control ([PR #134](https://github.com/RokuCommunity/roku-debug/pull/134))
+
+-   [@adellhk (adellhk)](https://github.com/adellhk)
+    -   Update create-vsix.yml ([PR #126](https://github.com/RokuCommunity/roku-debug/pull/126))
+-   [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
+    -   Execute command for repl expressions ([PR #119](https://github.com/RokuCommunity/roku-debug/pull/119))
+    -   Fix isAssignableExpression to correctly support dotted and indexed statements ([PR #128](https://github.com/RokuCommunity/roku-debug/pull/128))
+    -   Hiding prefixed variables in the debug variable panel ([PR #127](https://github.com/RokuCommunity/roku-debug/pull/127))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix inifinite-spin for unloaded vars ([PR #120](https://github.com/RokuCommunity/roku-debug/pull/120))
+    -   Fix off-by-1 bug with threads over protocol ([PR #132](https://github.com/RokuCommunity/roku-debug/pull/132))
+    -   Increase the timeout for debug protocol control ([PR #134](https://github.com/RokuCommunity/roku-debug/pull/134))
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fixing issues before release 0.8.1 ([5d84d9e](https://github.com/RokuCommunity/bslint/commit/5d84d9e))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fixing issues before release 0.8.1 ([5d84d9e](https://github.com/RokuCommunity/bslint/commit/5d84d9e))
 
 Contributions to [roku-report-analyzer](https://github.com/RokuCommunity/roku-report-analyzer):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix audit issues ([925c9f8](https://github.com/RokuCommunity/roku-report-analyzer/commit/925c9f8))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix audit issues ([925c9f8](https://github.com/RokuCommunity/roku-report-analyzer/commit/925c9f8))

--- a/src/pages/whats-new/2023-01-January.md
+++ b/src/pages/whats-new/2023-01-January.md
@@ -93,33 +93,38 @@ The link to the instalation instructions was broken. Now we have updated it to o
 Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - Fix rdb keypaths and focus scrolling ([PR #455](https://github.com/RokuCommunity/vscode-brightscript-language/pull/455))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - watch-all ([PR #456](https://github.com/RokuCommunity/vscode-brightscript-language/pull/456))
-    - Use png instead of svg ([d1e3d29](https://github.com/RokuCommunity/vscode-brightscript-language/commit/d1e3d29))
-    - Fix vsmarketplace badge ([b2153a3](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b2153a3))
-    - Fix dependency order in watch-all ([b7843a7](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b7843a7))
-    - fix: continue keyword colorization ([PR #459](https://github.com/RokuCommunity/vscode-brightscript-language/pull/459))
  - [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
     - Watch all dependency and configuration updates ([PR #460](https://github.com/RokuCommunity/vscode-brightscript-language/pull/460))
  - [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
     - Allow relative injectRaleTrackerTask ([PR #462](https://github.com/RokuCommunity/vscode-brightscript-language/pull/462))
+ - [@triwav (Brian Leighty)](https://github.com/triwav)
+    - Fix rdb keypaths and focus scrolling ([PR #455](https://github.com/RokuCommunity/vscode-brightscript-language/pull/455))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - watch-all ([PR #456](https://github.com/RokuCommunity/vscode-brightscript-language/pull/456))
+    - Fix vsmarketplace badge ([b2153a3](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b2153a3))
+    - Use png instead of svg ([d1e3d29](https://github.com/RokuCommunity/vscode-brightscript-language/commit/d1e3d29))
+    - fix: continue keyword colorization ([PR #459](https://github.com/RokuCommunity/vscode-brightscript-language/pull/459))
+    - Fix dependency order in watch-all ([b7843a7](https://github.com/RokuCommunity/vscode-brightscript-language/commit/b7843a7))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fixing issues before release 0.61.3 ([fd841a0](https://github.com/RokuCommunity/brighterscript/commit/fd841a0))
-    - Fix test-related-projects. Reenable rooibos ([PR #761](https://github.com/RokuCommunity/brighterscript/pull/761))
  - [@iObject (Tyler Smith)](https://github.com/iObject)
     - Add diagnostic for passing more than 5 arguments to a callFunc ([PR #765](https://github.com/RokuCommunity/brighterscript/pull/765))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Fix test-related-projects. Reenable rooibos ([PR #761](https://github.com/RokuCommunity/brighterscript/pull/761))
+    - Fixing issues before release 0.61.3 ([fd841a0](https://github.com/RokuCommunity/brighterscript/commit/fd841a0))
+
+Contributions to [logger](https://github.com/RokuCommunity/logger):
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Update build.yml ([6b13d47](https://github.com/RokuCommunity/logger/commit/6b13d47))
+    - Fix audit issues ([0583c2b](https://github.com/RokuCommunity/logger/commit/0583c2b))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
-    - Execute command for repl expressions ([PR #119](https://github.com/RokuCommunity/roku-debug/pull/119))
-    - Hiding prefixed variables in the debug variable panel ([PR #127](https://github.com/RokuCommunity/roku-debug/pull/127))
-    - Fix isAssignableExpression to correctly support dotted and indexed statements ([PR #128](https://github.com/RokuCommunity/roku-debug/pull/128))
  - [@adellhk (adellhk)](https://github.com/adellhk)
     - Update create-vsix.yml ([PR #126](https://github.com/RokuCommunity/roku-debug/pull/126))
+ - [@Christian-Holbrook (Christian-Holbrook)](https://github.com/Christian-Holbrook)
+    - Execute command for repl expressions ([PR #119](https://github.com/RokuCommunity/roku-debug/pull/119))
+    - Fix isAssignableExpression to correctly support dotted and indexed statements ([PR #128](https://github.com/RokuCommunity/roku-debug/pull/128))
+    - Hiding prefixed variables in the debug variable panel ([PR #127](https://github.com/RokuCommunity/roku-debug/pull/127))
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Fix inifinite-spin for unloaded vars ([PR #120](https://github.com/RokuCommunity/roku-debug/pull/120))
     - Fix off-by-1 bug with threads over protocol ([PR #132](https://github.com/RokuCommunity/roku-debug/pull/132))

--- a/src/pages/whats-new/2023-02-February.md
+++ b/src/pages/whats-new/2023-02-February.md
@@ -3,7 +3,9 @@ date: February 2023
 summary: Significant internal changes to internal debugger logic, progress on BrighterScript's File API and Component Statement
 layout: ../../layouts/WhatsNewPost.astro
 ---
+
 # Overview
+
 Not much happened this month in terms of released features. However, behind the scenes, [Bronley](https://github.com/TwitchBronBron) and [Chris](https://github.com/chrisdp) were hard at work on a massive overhaul of the debugger to improve testability and also to prepare for Roku's spring 2023 OS release. You can read a little more about it [here](#debug-protocol-refactor). We'll go into more detail once the pull request is finally merged.
 
 If you weren't already aware, the debug protocol is a new binary socket-based debugger that Roku introduced in Roku OS 9.2. The debug protocol is much more stable and consistent than our regex-powered telnet debugger because instead of scraping text, we're able to communicate with the Roku device directly using established data structures. You can enable the debug protocol by setting `"enableDebugProtocol": true"` in your `launch.json` in vscode.
@@ -11,24 +13,30 @@ If you weren't already aware, the debug protocol is a new binary socket-based de
 We've also made progress on the [File API](#file-api) and [Component Statement](#component-statement) implementations, so stay tuned for more information on those in the coming months.
 
 # Debugging
+
 ## Debug protocol refactor
+
 The code in [roku-debug](https://github.com/rokucommunity/roku-debug) is some of the oldest code in RokuCommunity, and has been historically very difficult to unit test because of how much it interacts with an actual Roku device. [roku-debug#107](https://github.com/rokucommunity/roku-debug/pull/107) makes great strides in improving that experience by creating a fully functional mock server that imitates Roku's debug protocol. This allows us to write much more extensive tests in our client code to ensure the binary data we're sending to the roku is valid, as well as verifying that we properly handle the incoming data. These changes also include improvements to the debug protocol logic that align us more closely with what we expect to see in Roku OS 12 which is likely to launch this spring.
 
 We'll do a larger writeup on all of these features when feature lands (hopefully sometime in March or early April), but you can take a look at the [pull request](https://github.com/rokucommunity/roku-debug/pull/107) if you're curious.
 
-
 # BrighterScript
+
 ## File API
+
 We've been hard at work designing the upcoming [file API](https://github.com/rokucommunity/brighterscript/pull/408) for BrighterScript. Currently in BrighterScript, only `.brs`,`.bs`, and `.xml` files are loaded into the program. All other files are copied as-is from `./src` to `./staging`. Even manifest files are only loaded in read-only mode and cannot be changed by plugins. The file API introduced in [BrighterScript#408](https://github.com/rokucommunity/brighterscript/pull/408) will empower brighterscript plugins to process, transform, and even completely rewrite files of any type. We're excited to see what the community will do with these new features, so hopefully we can get it finished up in the next few months.
 
 ## Component Statement
-Component statement is a proposal to the BrighterScript language that would allow developers to define SceneGraph components *in brighterscript code* instead of xml. It's built off the foundations of the [File API](#file-api), and is being used to validate that the File API is functionally capable of its goals. You can read more about the Component Statmenet designs in [this PR](https://github.com/rokucommunity/brighterscript/pull/575), and we're hopeful to land this feature before summer.
+
+Component statement is a proposal to the BrighterScript language that would allow developers to define SceneGraph components _in brighterscript code_ instead of xml. It's built off the foundations of the [File API](#file-api), and is being used to validate that the File API is functionally capable of its goals. You can read more about the Component Statmenet designs in [this PR](https://github.com/rokucommunity/brighterscript/pull/575), and we're hopeful to land this feature before summer.
 
 # Thank you
-Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Debug protocol server ([PR #107](https://github.com/RokuCommunity/roku-debug/pull/107))
- - [@chrisdp (Christopher Dwyer-Perkins)](https://github.com/chrisdp)
-    - Debug protocol server ([PR #107](https://github.com/RokuCommunity/roku-debug/pull/107))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Debug protocol server ([PR #107](https://github.com/RokuCommunity/roku-debug/pull/107))
+-   [@chrisdp (Christopher Dwyer-Perkins)](https://github.com/chrisdp)
+    -   Debug protocol server ([PR #107](https://github.com/RokuCommunity/roku-debug/pull/107))

--- a/src/pages/whats-new/2023-03-March.md
+++ b/src/pages/whats-new/2023-03-March.md
@@ -46,7 +46,7 @@ Here's a quick demo showing it in action:
 
 # BrighterScript
 ## Fixed transpile bug with optional chaining
-When transpiling optional chaining expressions, there was a bug where the final `?.` in the chain would lose the `?` when used in an assignment statement. As of brighterscript@0.62.0, the bsc compiler will now produce proper output. ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781)). However, keep in mind that this is not valid syntax and the device will throw a runtime error if this syntax is used. To help with that, brighterscript will flag whenever optional chaining is used in assignments. 
+When transpiling optional chaining expressions, there was a bug where the final `?.` in the chain would lose the `?` when used in an assignment statement. As of brighterscript@0.62.0, the bsc compiler will now produce proper output. ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781)). However, keep in mind that this is not valid syntax and the device will throw a runtime error if this syntax is used. To help with that, brighterscript will flag whenever optional chaining is used in assignments.
 
 __Before:__
 ![image](https://user-images.githubusercontent.com/2544493/234055473-5598d7a9-f172-43b6-b647-6d24d4f50dd5.png)
@@ -66,7 +66,7 @@ __After fix:__
 
 ![image](https://user-images.githubusercontent.com/2544493/234249265-1d5276aa-038d-4b80-ae05-bde940bb9c74.png)
 
- - brighterscript: Wrap transpiled template strings in parens 
+ - brighterscript: Wrap transpiled template strings in parens
 
 
 ## Changes for BrighterScript plugin authors
@@ -85,7 +85,7 @@ Fixed a crash in @rokucommunity/logger (used by all our RokuCommunity projects) 
 
 
 ## Build status badges
-All of our "build status" badges stopped working in December 2022 because shields.io change the URL format for the badge. This month we spent a little time to fix them all 
+All of our "build status" badges stopped working in December 2022 because shields.io change the URL format for the badge. This month we spent a little time to fix them all
 ([1b31d04](https://github.com/RokuCommunity/brighterscript/commit/1b31d04),
    [9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6),
    [248a853](https://github.com/RokuCommunity/roku-report-analyzer/commit/248a853),
@@ -95,7 +95,7 @@ All of our "build status" badges stopped working in December 2022 because shield
    [b3f0b0d](https://github.com/rokucommunity/vscode-brightscript-language/commit/b3f0b0d)
 )
 
-We turned this: 
+We turned this:
 [![build status](https://img.shields.io/github/workflow/status/rokucommunity/brighterscript/build.svg?logo=github)](https://github.com/rokucommunity/brighterscript/actions?query=workflow%3Abuild)
 
 back into this:
@@ -106,69 +106,63 @@ back into this:
 ## Exclude node_modules when debugging roku-debug in Node.js
 When debugging the typescript code in roku-debug, breakpoints should work a lot better now. There was a bug that was incorrectly resolving the sourcemaps in the wrong locations, which often meant that contributors had to fall back to using hardcoded `debugger;` statements in their typescript code. ([a4a3de2](https://github.com/RokuCommunity/vscode-brightscript-language/commit/a4a3de2))
 
+
 # Thank you
 Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
  - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - Fix Roku Commands view, start using createCommandMessage more consist… ([PR #471](https://github.com/RokuCommunity/vscode-brightscript-language/pull/471))
     - Add device view with direct node selection ([PR #465](https://github.com/RokuCommunity/vscode-brightscript-language/pull/465))
+    - Fix Roku Commands view, start using createCommandMessage more consist… ([PR #471](https://github.com/RokuCommunity/vscode-brightscript-language/pull/471))
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Use ubuntu-latest ([f62b506](https://github.com/RokuCommunity/vscode-brightscript-language/commit/f62b506))
     - Fix roku-debug breakpoints ([a4a3de2](https://github.com/RokuCommunity/vscode-brightscript-language/commit/a4a3de2))
+    - Use ubuntu-latest ([f62b506](https://github.com/RokuCommunity/vscode-brightscript-language/commit/f62b506))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Add github icon back into build status badge ([30d25ae](https://github.com/RokuCommunity/brighterscript/commit/30d25ae))
-    - Another build status badge fix ([9250656](https://github.com/RokuCommunity/brighterscript/commit/9250656))
-    - Fix build status badge ([1b31d04](https://github.com/RokuCommunity/brighterscript/commit/1b31d04))
-    - Optional chaining assignment validation ([PR #782](https://github.com/RokuCommunity/brighterscript/pull/782))
-    - Fix transpile bug with optional chaning ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781))
-    - Fix crash when func has no block ([PR #774](https://github.com/RokuCommunity/brighterscript/pull/774))
-    - Remove invalid annotation example ([8d3d74e](https://github.com/RokuCommunity/brighterscript/commit/8d3d74e))
-    - Move not-referenced check into ProgramValidator ([PR #773](https://github.com/RokuCommunity/brighterscript/pull/773))
-    - Wrap transpiled template strings in parens ([PR #788](https://github.com/RokuCommunity/brighterscript/pull/788))
-    - Simplify the ast range logic ([PR #784](https://github.com/RokuCommunity/brighterscript/pull/784))
  - [@elsassph (Philippe Elsass)](https://github.com/elsassph)
     - Add 'severityOverride' option ([PR #725](https://github.com/RokuCommunity/brighterscript/pull/725))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Move not-referenced check into ProgramValidator ([PR #773](https://github.com/RokuCommunity/brighterscript/pull/773))
+    - Remove invalid annotation example ([8d3d74e](https://github.com/RokuCommunity/brighterscript/commit/8d3d74e))
+    - Fix crash when func has no block ([PR #774](https://github.com/RokuCommunity/brighterscript/pull/774))
+    - Fix transpile bug with optional chaning ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781))
+    - Optional chaining assignment validation ([PR #782](https://github.com/RokuCommunity/brighterscript/pull/782))
+    - Fix build status badge ([1b31d04](https://github.com/RokuCommunity/brighterscript/commit/1b31d04))
+    - Another build status badge fix ([9250656](https://github.com/RokuCommunity/brighterscript/commit/9250656))
+    - Add github icon back into build status badge ([30d25ae](https://github.com/RokuCommunity/brighterscript/commit/30d25ae))
+    - Simplify the ast range logic ([PR #784](https://github.com/RokuCommunity/brighterscript/pull/784))
+    - Wrap transpiled template strings in parens ([PR #788](https://github.com/RokuCommunity/brighterscript/pull/788))
 
 Contributions to [roku-deploy](https://github.com/RokuCommunity/roku-deploy):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Use micromatch instead of picomatch ([PR #109](https://github.com/RokuCommunity/roku-deploy/pull/109))
- - [@dependabot[bot] (dependabot[bot])](https://github.com/apps/dependabot)
-    - Bump qs from 6.5.2 to 6.5.3 ([PR #105](https://github.com/RokuCommunity/roku-deploy/pull/105))
-    - Bump jszip from 3.7.1 to 3.8.0 ([PR #108](https://github.com/RokuCommunity/roku-deploy/pull/108))
 
 Contributions to [logger](https://github.com/RokuCommunity/logger):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix crash when encountering bigint ([PR #3](https://github.com/RokuCommunity/logger/pull/3))
     - Reduce CI builds for PRs ([7787a00](https://github.com/RokuCommunity/logger/commit/7787a00))
+    - Fix crash when encountering bigint ([PR #3](https://github.com/RokuCommunity/logger/pull/3))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Fix build status badge ([a9573f1](https://github.com/RokuCommunity/roku-debug/commit/a9573f1))
- - [@dependabot[bot] (dependabot[bot])](https://github.com/apps/dependabot)
-    - Bump jszip from 3.7.1 to 3.10.1 ([PR #135](https://github.com/RokuCommunity/roku-debug/pull/135))
 
 Contributions to [brighterscript-formatter](https://github.com/RokuCommunity/brighterscript-formatter):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Add github logo back to build status badge ([5f0d04b](https://github.com/RokuCommunity/brighterscript-formatter/commit/5f0d04b))
-    - Fix build status badge ([9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6))
-    - Fix indent format issue related to optional chaining array access ([PR #71](https://github.com/RokuCommunity/brighterscript-formatter/pull/71))
  - [@casonadams (Cason Adams)](https://github.com/casonadams)
     - update readme ([PR #72](https://github.com/RokuCommunity/brighterscript-formatter/pull/72))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Fix indent format issue related to optional chaining array access ([PR #71](https://github.com/RokuCommunity/brighterscript-formatter/pull/71))
+    - Fix build status badge ([9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6))
+    - Add github logo back to build status badge ([5f0d04b](https://github.com/RokuCommunity/brighterscript-formatter/commit/5f0d04b))
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix build status badge ([cf63684](https://github.com/RokuCommunity/bslint/commit/cf63684))
  - [@cewert (Charles Ewert)](https://github.com/cewert)
     - add "eol-last" to list of default rules ([PR #84](https://github.com/RokuCommunity/bslint/pull/84))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Fix build status badge ([cf63684](https://github.com/RokuCommunity/bslint/commit/cf63684))
 
 Contributions to [ropm](https://github.com/RokuCommunity/ropm):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - fix build status badge ([fc087d8](https://github.com/RokuCommunity/ropm/commit/fc087d8))
- - [@dependabot[bot] (dependabot[bot])](https://github.com/apps/dependabot)
-    - Bump jszip from 3.7.1 to 3.10.1 ([PR #68](https://github.com/RokuCommunity/ropm/pull/68))
 
 Contributions to [roku-report-analyzer](https://github.com/RokuCommunity/roku-report-analyzer):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)

--- a/src/pages/whats-new/2023-03-March.md
+++ b/src/pages/whats-new/2023-03-March.md
@@ -5,14 +5,17 @@ layout: ../../layouts/WhatsNewPost.astro
 ---
 
 # Debugging
+
 ## New Device View with interactive node inspector
+
 We introduced a new "Device View" panel in vscode extension version v2.39.0 that can be used while debugging to view the current video output of the active Roku. We achive this by capturing screenshots as fast as the Roku will provide them (roughly 1 image per second). Perhaps the coolest feature of this new panel is the interactive node inspector which is similar to the "inspect element" feature in modern web based developer tools. When activated, you can hover over any part of the screenshot and it will show the current SGNode and focus that node in the tree view. ([#465](https://github.com/RokuCommunity/vscode-brightscript-language/pull/465))
 
- ![device view](https://user-images.githubusercontent.com/2544493/234414091-9e2e85be-51d3-4493-a0ee-92037c152938.gif)
+![device view](https://user-images.githubusercontent.com/2544493/234414091-9e2e85be-51d3-4493-a0ee-92037c152938.gif)
 
 # Formatting
 
 ## Fix formatting for indenting optional chaining expressions inside arrays ([#71](https://github.com/RokuCommunity/brighterscript-formatter/pull/71))
+
 We fixed a bug in the indent formatter that would incorrectly de-indent whenever the `?[` token was encountered.
 
 **Before:**
@@ -24,75 +27,84 @@ We fixed a bug in the indent formatter that would incorrectly de-indent whenever
 ![image](https://user-images.githubusercontent.com/2544493/234317169-eaf98411-26ef-4745-9790-35baf38c58d6.png)
 
 # Language Features
+
 ## Flag using optional chaining in left-hand-side of assignments
+
 The vscode extension (and BrighterScript) now properly flags when using optional chaining in the left-hand-side of assignments since doing that will cause a runtime error on-device. ([#782](https://github.com/RokuCommunity/brighterscript/pull/782))
 ![image](https://user-images.githubusercontent.com/2544493/233837189-3c3dc798-2b6f-4d22-8bdf-0d210eafaf62.png)
 
 ## New `severityOverride` option
+
 BrighterScript v0.62.0 added a new 'severityOverride' option that can be used to increase or decrease the severity of diagnostics. ([#725](https://github.com/RokuCommunity/brighterscript/pull/725))
 
 For example, consider the `bs1013` warning which says `"This file is not referenced by any other file in the project"`. If you wanted to turn that warning into an error, update the bsconfig as follows:
 
 ```jsonc
 {
-   "diagnosticSeverityOverrides": {
-      "1013": "error"
-   }
+    "diagnosticSeverityOverrides": {
+        "1013": "error"
+    }
 }
 ```
+
 Here's a quick demo showing it in action:
 
 ![diagnostic-severity-override](https://user-images.githubusercontent.com/2544493/234058500-4510e12b-9d5f-4a49-aaf5-1fd6901a034d.gif)
 
 # BrighterScript
+
 ## Fixed transpile bug with optional chaining
+
 When transpiling optional chaining expressions, there was a bug where the final `?.` in the chain would lose the `?` when used in an assignment statement. As of brighterscript@0.62.0, the bsc compiler will now produce proper output. ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781)). However, keep in mind that this is not valid syntax and the device will throw a runtime error if this syntax is used. To help with that, brighterscript will flag whenever optional chaining is used in assignments.
 
-__Before:__
+**Before:**
 ![image](https://user-images.githubusercontent.com/2544493/234055473-5598d7a9-f172-43b6-b647-6d24d4f50dd5.png)
 
-__After__:
+**After**:
 ![image](https://user-images.githubusercontent.com/2544493/234250966-d51a064a-5701-4af9-8b6e-5e57a8f9454b.png)
 
-
 ## Safer template string output
+
 BrighterScript@0.63.0 fixed a bug in the template string transpiler where trailing function attached to the last chunk of the template string instead of the full transpiled string. That has been fixed by wrapping the entire template string output in parentheses. ([#788](https://github.com/RokuCommunity/brighterscript/pull/788))
 
-__Before fix:__
+**Before fix:**
 
 ![image](https://user-images.githubusercontent.com/2544493/234248849-80b2c10f-f8a6-49d0-964c-f153bb93b28a.png)
 
-__After fix:__
+**After fix:**
 
 ![image](https://user-images.githubusercontent.com/2544493/234249265-1d5276aa-038d-4b80-ae05-bde940bb9c74.png)
 
- - brighterscript: Wrap transpiled template strings in parens
-
+-   brighterscript: Wrap transpiled template strings in parens
 
 ## Changes for BrighterScript plugin authors
- - fix crash when func has no block ([#774](https://github.com/RokuCommunity/brighterscript/pull/774))
- - move not-referenced check into ProgramValidator ([#773](https://github.com/RokuCommunity/brighterscript/pull/773))
- - simplify the ast range logic ([#784](https://github.com/RokuCommunity/brighterscript/pull/784))
+
+-   fix crash when func has no block ([#774](https://github.com/RokuCommunity/brighterscript/pull/774))
+-   move not-referenced check into ProgramValidator ([#773](https://github.com/RokuCommunity/brighterscript/pull/773))
+-   simplify the ast range logic ([#784](https://github.com/RokuCommunity/brighterscript/pull/784))
 
 # Misc
+
 ## roku-deploy now uses micromatch instead of picomatch
+
 roku-deploy internally uses [fast-glob](https://www.npmjs.com/package/fast-glob) for file discovery (which uses [micromatch](https://www.npmjs.com/package/micromatch) for glob logic), but for some reason was using [picomatch](https://www.npmjs.com/package/picomatch) for the path filtering logic.
 
 [roku-deploy#109](https://github.com/RokuCommunity/roku-deploy/pull/109) aligns on [micromatch](https://www.npmjs.com/package/micromatch) for path filtering logic, meaning that now all glob logic within roku-deploy is handled using the same library.
 
 ## @rokucommunity/logger BigInt crash fix
+
 Fixed a crash in @rokucommunity/logger (used by all our RokuCommunity projects) when trying to serialize bigint ([@rokucommunity/logger#3](https://github.com/RokuCommunity/logger/pull/3))
 
-
 ## Build status badges
+
 All of our "build status" badges stopped working in December 2022 because shields.io change the URL format for the badge. This month we spent a little time to fix them all
 ([1b31d04](https://github.com/RokuCommunity/brighterscript/commit/1b31d04),
-   [9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6),
-   [248a853](https://github.com/RokuCommunity/roku-report-analyzer/commit/248a853),
-   [fc087d8](https://github.com/RokuCommunity/ropm/commit/fc087d8),
-   [cf63684](https://github.com/RokuCommunity/bslint/commit/cf63684),
-   [a9573f1](https://github.com/RokuCommunity/roku-debug/commit/a9573f1)
-   [b3f0b0d](https://github.com/rokucommunity/vscode-brightscript-language/commit/b3f0b0d)
+[9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6),
+[248a853](https://github.com/RokuCommunity/roku-report-analyzer/commit/248a853),
+[fc087d8](https://github.com/RokuCommunity/ropm/commit/fc087d8),
+[cf63684](https://github.com/RokuCommunity/bslint/commit/cf63684),
+[a9573f1](https://github.com/RokuCommunity/roku-debug/commit/a9573f1)
+[b3f0b0d](https://github.com/rokucommunity/vscode-brightscript-language/commit/b3f0b0d)
 )
 
 We turned this:
@@ -101,69 +113,79 @@ We turned this:
 back into this:
 [![build status](https://img.shields.io/github/actions/workflow/status/rokucommunity/brighterscript/build.yml?logo=github)](https://github.com/rokucommunity/brighterscript/actions?query=branch%3Amaster+workflow%3Abuild)
 
-
 # Contributing
+
 ## Exclude node_modules when debugging roku-debug in Node.js
+
 When debugging the typescript code in roku-debug, breakpoints should work a lot better now. There was a bug that was incorrectly resolving the sourcemaps in the wrong locations, which often meant that contributors had to fall back to using hardcoded `debugger;` statements in their typescript code. ([a4a3de2](https://github.com/RokuCommunity/vscode-brightscript-language/commit/a4a3de2))
 
-
 # Thank you
-Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - Add device view with direct node selection ([PR #465](https://github.com/RokuCommunity/vscode-brightscript-language/pull/465))
-    - Fix Roku Commands view, start using createCommandMessage more consist… ([PR #471](https://github.com/RokuCommunity/vscode-brightscript-language/pull/471))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix roku-debug breakpoints ([a4a3de2](https://github.com/RokuCommunity/vscode-brightscript-language/commit/a4a3de2))
-    - Use ubuntu-latest ([f62b506](https://github.com/RokuCommunity/vscode-brightscript-language/commit/f62b506))
+
+-   [@triwav (Brian Leighty)](https://github.com/triwav)
+    -   Add device view with direct node selection ([PR #465](https://github.com/RokuCommunity/vscode-brightscript-language/pull/465))
+    -   Fix Roku Commands view, start using createCommandMessage more consist… ([PR #471](https://github.com/RokuCommunity/vscode-brightscript-language/pull/471))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix roku-debug breakpoints ([a4a3de2](https://github.com/RokuCommunity/vscode-brightscript-language/commit/a4a3de2))
+    -   Use ubuntu-latest ([f62b506](https://github.com/RokuCommunity/vscode-brightscript-language/commit/f62b506))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@elsassph (Philippe Elsass)](https://github.com/elsassph)
-    - Add 'severityOverride' option ([PR #725](https://github.com/RokuCommunity/brighterscript/pull/725))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Move not-referenced check into ProgramValidator ([PR #773](https://github.com/RokuCommunity/brighterscript/pull/773))
-    - Remove invalid annotation example ([8d3d74e](https://github.com/RokuCommunity/brighterscript/commit/8d3d74e))
-    - Fix crash when func has no block ([PR #774](https://github.com/RokuCommunity/brighterscript/pull/774))
-    - Fix transpile bug with optional chaning ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781))
-    - Optional chaining assignment validation ([PR #782](https://github.com/RokuCommunity/brighterscript/pull/782))
-    - Fix build status badge ([1b31d04](https://github.com/RokuCommunity/brighterscript/commit/1b31d04))
-    - Another build status badge fix ([9250656](https://github.com/RokuCommunity/brighterscript/commit/9250656))
-    - Add github icon back into build status badge ([30d25ae](https://github.com/RokuCommunity/brighterscript/commit/30d25ae))
-    - Simplify the ast range logic ([PR #784](https://github.com/RokuCommunity/brighterscript/pull/784))
-    - Wrap transpiled template strings in parens ([PR #788](https://github.com/RokuCommunity/brighterscript/pull/788))
+
+-   [@elsassph (Philippe Elsass)](https://github.com/elsassph)
+    -   Add 'severityOverride' option ([PR #725](https://github.com/RokuCommunity/brighterscript/pull/725))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Move not-referenced check into ProgramValidator ([PR #773](https://github.com/RokuCommunity/brighterscript/pull/773))
+    -   Remove invalid annotation example ([8d3d74e](https://github.com/RokuCommunity/brighterscript/commit/8d3d74e))
+    -   Fix crash when func has no block ([PR #774](https://github.com/RokuCommunity/brighterscript/pull/774))
+    -   Fix transpile bug with optional chaning ([PR #781](https://github.com/RokuCommunity/brighterscript/pull/781))
+    -   Optional chaining assignment validation ([PR #782](https://github.com/RokuCommunity/brighterscript/pull/782))
+    -   Fix build status badge ([1b31d04](https://github.com/RokuCommunity/brighterscript/commit/1b31d04))
+    -   Another build status badge fix ([9250656](https://github.com/RokuCommunity/brighterscript/commit/9250656))
+    -   Add github icon back into build status badge ([30d25ae](https://github.com/RokuCommunity/brighterscript/commit/30d25ae))
+    -   Simplify the ast range logic ([PR #784](https://github.com/RokuCommunity/brighterscript/pull/784))
+    -   Wrap transpiled template strings in parens ([PR #788](https://github.com/RokuCommunity/brighterscript/pull/788))
 
 Contributions to [roku-deploy](https://github.com/RokuCommunity/roku-deploy):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Use micromatch instead of picomatch ([PR #109](https://github.com/RokuCommunity/roku-deploy/pull/109))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Use micromatch instead of picomatch ([PR #109](https://github.com/RokuCommunity/roku-deploy/pull/109))
 
 Contributions to [logger](https://github.com/RokuCommunity/logger):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Reduce CI builds for PRs ([7787a00](https://github.com/RokuCommunity/logger/commit/7787a00))
-    - Fix crash when encountering bigint ([PR #3](https://github.com/RokuCommunity/logger/pull/3))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Reduce CI builds for PRs ([7787a00](https://github.com/RokuCommunity/logger/commit/7787a00))
+    -   Fix crash when encountering bigint ([PR #3](https://github.com/RokuCommunity/logger/pull/3))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix build status badge ([a9573f1](https://github.com/RokuCommunity/roku-debug/commit/a9573f1))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix build status badge ([a9573f1](https://github.com/RokuCommunity/roku-debug/commit/a9573f1))
 
 Contributions to [brighterscript-formatter](https://github.com/RokuCommunity/brighterscript-formatter):
- - [@casonadams (Cason Adams)](https://github.com/casonadams)
-    - update readme ([PR #72](https://github.com/RokuCommunity/brighterscript-formatter/pull/72))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix indent format issue related to optional chaining array access ([PR #71](https://github.com/RokuCommunity/brighterscript-formatter/pull/71))
-    - Fix build status badge ([9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6))
-    - Add github logo back to build status badge ([5f0d04b](https://github.com/RokuCommunity/brighterscript-formatter/commit/5f0d04b))
+
+-   [@casonadams (Cason Adams)](https://github.com/casonadams)
+    -   update readme ([PR #72](https://github.com/RokuCommunity/brighterscript-formatter/pull/72))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix indent format issue related to optional chaining array access ([PR #71](https://github.com/RokuCommunity/brighterscript-formatter/pull/71))
+    -   Fix build status badge ([9df64c6](https://github.com/RokuCommunity/brighterscript-formatter/commit/9df64c6))
+    -   Add github logo back to build status badge ([5f0d04b](https://github.com/RokuCommunity/brighterscript-formatter/commit/5f0d04b))
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
- - [@cewert (Charles Ewert)](https://github.com/cewert)
-    - add "eol-last" to list of default rules ([PR #84](https://github.com/RokuCommunity/bslint/pull/84))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix build status badge ([cf63684](https://github.com/RokuCommunity/bslint/commit/cf63684))
+
+-   [@cewert (Charles Ewert)](https://github.com/cewert)
+    -   add "eol-last" to list of default rules ([PR #84](https://github.com/RokuCommunity/bslint/pull/84))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix build status badge ([cf63684](https://github.com/RokuCommunity/bslint/commit/cf63684))
 
 Contributions to [ropm](https://github.com/RokuCommunity/ropm):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - fix build status badge ([fc087d8](https://github.com/RokuCommunity/ropm/commit/fc087d8))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   fix build status badge ([fc087d8](https://github.com/RokuCommunity/ropm/commit/fc087d8))
 
 Contributions to [roku-report-analyzer](https://github.com/RokuCommunity/roku-report-analyzer):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix gh workflow badge svg ([248a853](https://github.com/RokuCommunity/roku-report-analyzer/commit/248a853))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix gh workflow badge svg ([248a853](https://github.com/RokuCommunity/roku-report-analyzer/commit/248a853))

--- a/src/pages/whats-new/2023-04-April.md
+++ b/src/pages/whats-new/2023-04-April.md
@@ -1,24 +1,25 @@
 ---
 date: April 2023
-summary:  WSL compatibility fixes, performance improvements across editing and debugging, stability fixes, BrighterScript bug fixes, an update on type tracking, and more!
+summary: WSL compatibility fixes, performance improvements across editing and debugging, stability fixes, BrighterScript bug fixes, an update on type tracking, and more!
 layout: ../../layouts/WhatsNewPost.astro
 ---
+
 # Overview
 
 We've made a lot of good progress this month, including WSL compatibility fixes, performance improvements across editing and debugging, stability fixes, BrighterScript bug fixes, and more!
 
-
 # Editor
 
 ## Device View and SceneGraph Inspector now works in WSL!
+
 Last month we introduced the new [Device View](https://rokucommunity.github.io/whats-new/2023-03-March/#new-device-view-with-interactive-node-inspector) panel, and the SceneGraph Inspector panel has been there for a while now. However, both of these views were broken when running the BrightScript Language extension for VSCode inside of [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/about). Well, we [fixed it](https://github.com/RokuCommunity/vscode-brightscript-language/pull/478)! Starting in [v2.40.1](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2401---2023-04-28) of the extension, you can now use all of these nifty features in WSL. ([@georgejecook](https://github.com/georgejecook), this one's for you 😉)
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/f5c85fea-9e3e-46ec-89cb-cfc180f1c033)
 
-
 In addition to the WSL fixes, we also made a few [performance improvements](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477) and [UI tweaks](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477) to the SceneGraph Inspector that should make it nicer to use.
 
 ## Small language server performance boost
+
 [brighterscript#797](https://github.com/RokuCommunity/brighterscript/pull/797) adds a small performance boost to the language server by optimizing the `AstNode.getSymbolTable()` method. There are no changes to the way you code, but enjoy the free speed boost! This is available starting in [BrighterScript v0.64.3](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0643---2023-04-28) and [BrightScript Language extension for VSCode v2.40.1](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2401---2023-04-28)
 
 Before:
@@ -29,10 +30,10 @@ After:
 
 ![image](https://user-images.githubusercontent.com/2544493/233732843-42f08221-45de-49ea-99b7-1707567ac1f8.png)
 
-
 # Debugging
 
 ## Exclude sourcemaps when sideloading
+
 Many preprocessors such as BrighterScript or gulp plugins will generate sourcemaps alongside the generated files, which are a way to link a generated file, line, and column location back to its original location. The BrightScript language extension for VSCode fully supports reading these sourcemaps to improve the debugging experience with projects that leverage a preprocessor. However, sourcemaps are fairly large, sometimes even as large as the generated file itself.
 
 ![image](https://github.com/rokucommunity/rokucommunity.github.io/assets/2544493/c5a172a3-fec3-4035-9ae3-669a43858298)
@@ -58,6 +59,7 @@ Packaging projects took: 2s411ms, Uploading zip took 5920ms, AppCompileComplete 
 ```
 
 ## Better error handling for RALE integration
+
 The BrightScript Language extension for VSCode has basic support for [RALE integration](https://rokucommunity.github.io/vscode-brightscript-language/Debugging/rale.html). When enabled, the extension can auto-inject the RALE tracker task init code into your project by replacing a specific comment with the tracker task init logic. However, there was a bug where the debug session would crash with a very obscure message if `injectRaleTrackerTask` was enabled but the file at `raleTrackerTaskFileLocation` was missing or the property was omitted entirely.
 
 As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0), this flow has been improved to now show a much more helpful error notification.
@@ -65,21 +67,25 @@ As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brights
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/414beed6-54d5-4556-9120-19a664c9d083)
 
 ## Better error reporting for launch.json validation crashes
+
 At the start of a debug session in VSCode, the BrightScript Language extension will validate and sanitize the selected `launch.json` configuration. Sometimes a runtime exception can occur during this process. In the past, these crash stack traces weren't avaiable to the developer. As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0), the entire launch config validation flow is now wrapped in a `try`/`catch` so we can log exceptions to the output channel, which should give developers access to much more useful feedback for future crashes.
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/bd6fcaae-cf7e-4cff-b07d-de53196ca266)
 
-
 ## Add better error for failed session starts
+
 If you've been using the vscode extension for a while now, you've probably encountered situations where the debug session just randomly shuts down, with no warning or explanation. Starting in release [v2.40.1](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2401---2023-04-28), many of these crashes will now show a much more helpful error popup.
 
 ## Wrap the dnsLookup for host in a try/catch
+
 Rather than trying to remember several different IP addresses, another way of referencing your Rokus is by DNS name. Many routers allow statically assigning a host name to a device on the network. For example, Roku 192.168.1.25 could be given the name "`roku-streaming-stick1`". At the start of a debug session, the vscode extension will do a DNS lookup and translate that DNS name back to its local IP address.
 
 However, in some situations, that DNS lookup could fail, and we were not properly handling that failure and instead would crash the debug session. This has been fixed in [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2400---2023-04-18) of the BrightScript Language extension for VSCode so that, if the DNS lookup fails, we'll attempt to use the DNS name as-is, which sometimes still works.
 
 # BrighterScript
+
 ## bslint now works with `const`
+
 If you've used the `const` feature in BrighterScript (introduced in [v0.53.0](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0530---2022-07-14)) and also [bslint](https://github.com/rokucommunity/bslint), you may have noticed that bslint would incorrectly show errors whenever you tried to reference those consts.
 
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/c63000da-3316-400a-aebf-bf0bc3484f63)
@@ -89,19 +95,21 @@ This has been fixed and is available starting in [bslint v0.8.3](https://github.
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/bcd949c0-1b09-4552-b42b-6dd612e55a31)
 
 ## Fix namespace-inferred items
+
 BrighterScript has a feature in nested namespaces where all the items in that same namespace can be referenced _without_ needing to include the full leading namespace part. We call this "namespace inference", which you can read about [here](https://github.com/rokucommunity/brighterscript/blob/master/docs/namespaces.md#namespace-inference). As a result of supporting this feature, certain names become unavailable for use as variable identifiers when they conflict with inferred namespace names. These variables are now properly flagged as errors starting in BrighterScript [v0.64.0](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0640---2023-04-04).
 
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/5da43e85-9695-41e8-849e-3cc8b699d428)
 
 ## Fix semantic tokens for namespaces
+
 Semantic tokens are a way for the language server to enhance syntax highlighting for certain tokens, based on more complex language semantics that regex-based textmate grammar syntax highlighting isn't capable of supporting. We've fixed several bugs in bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...v0.64.0) related to namespace semantic tokens when they're used in assignment statements and function parameters.
 
 TL;DR: namespaces are prettier now!
 
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/1da1f188-b224-40bc-bd03-0bd578f5a21b)
 
-
 ## Fix namespace-inferred enum value
+
 BrighterScript [v0.64.2](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0642---2023-04-18) fixed a validation bug that was incorrectly flagging namespace-inferred enum values as errors.
 
 **Before:**
@@ -110,10 +118,9 @@ BrighterScript [v0.64.2](https://github.com/rokucommunity/brighterscript/blob/ma
 **After:**
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/290b3a9c-08a0-4c77-94ed-24c284bba635)
 
-
-
 ## Enum member lookups are now case INsensitive
-bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...v0.64.0)  fixed several situations where enums and enum members were incorrectly handled as case _sensitive_, when they should both be handled case-_INsensitive_ to align with standard brightscript language design.
+
+bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...v0.64.0) fixed several situations where enums and enum members were incorrectly handled as case _sensitive_, when they should both be handled case-_INsensitive_ to align with standard brightscript language design.
 
 **Before:**
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/48bce55d-a7ae-4ffa-ab97-870d6e74d090)
@@ -123,6 +130,7 @@ bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/549f1b74-bfcf-40a6-82d5-214476783bd8)
 
 ## Type tracking coming soon
+
 [markwpearce (Mark Pearce)](https://github.com/markwpearce) has been making incredible progress on type tracking and validation in BrighterScript. We're currently working on improving its performance. The validation flow has slowed down significantly as a result of all the new type tracking goodness we're running, but we have some ideas on how to gain back most of that performance so stay tuned.
 
 Also, for BrighterScript Plugin authors, be aware that there are some **BREAKING CHANGES** coming to the BrightScript AST. We've tried to keep them as minimal as possible and we hope to release them all at the same time when type tracking lands in the next month or two so that you can fix all of the errors at the same time. We'll provide a full writeup of the changes once the feature lands.
@@ -133,7 +141,9 @@ Here are a few examples of some new validations that are coming soon:
 You can follow our progress on type tracking in [BrighterScript#783](https://github.com/rokucommunity/brighterscript/pull/783).
 
 # Misc
+
 ## Fix some more github status badges
+
 [Last month](https://rokucommunity.github.io/whats-new/2023-03-March/#build-status-badges) we fixed most of our github status badges, but we made a few mistakes, which have now been corrected. ([roku-deploy](https://github.com/RokuCommunity/roku-deploy/commit/ad2c9ec), [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language/pull/474))
 
 ![image](https://github.com/rokucommunity/roku-deploy/assets/2544493/18f62ddf-c604-40bd-ba2c-6918b2871ffb)
@@ -141,44 +151,51 @@ You can follow our progress on type tracking in [BrighterScript#783](https://git
 # For Contributors
 
 ## Add cpuprofile ability to BrighterScript benchmarks
-For developers who work on the BrighterScript compiler, we have a handy benchmarking tool that helps compare the current performance against the latest release.  ([#796](https://github.com/RokuCommunity/brighterscript/pull/796)) adds a `--profile` cli flag that will generate a `.cpuprofile` file that can be used to identify [hot spots](https://en.wikipedia.org/wiki/Hot_spot_(computer_programming)) that need to be optimized. We also fixed some stability issues in the benchmark project ([#795](https://github.com/RokuCommunity/brighterscript/pull/795))
+
+For developers who work on the BrighterScript compiler, we have a handy benchmarking tool that helps compare the current performance against the latest release. ([#796](https://github.com/RokuCommunity/brighterscript/pull/796)) adds a `--profile` cli flag that will generate a `.cpuprofile` file that can be used to identify [hot spots](<https://en.wikipedia.org/wiki/Hot_spot_(computer_programming)>) that need to be optimized. We also fixed some stability issues in the benchmark project ([#795](https://github.com/RokuCommunity/brighterscript/pull/795))
 
 # Thank you
-Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
- - [@cewert (Charles Ewert)](https://github.com/cewert)
-    - Fix build badge ([PR #474](https://github.com/RokuCommunity/vscode-brightscript-language/pull/474))
- - [@jean-guyrivard (Jean-Guy Rivard)](https://github.com/jean-guyrivard)
-    - Added validation for raleTrackerTaskFileLocation setting existence. ([PR #472](https://github.com/RokuCommunity/vscode-brightscript-language/pull/472))
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - Run find node calculations in webview and other improvements ([PR #477](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Wrap the dnsLookup for host in a try/catch ([PR #473](https://github.com/RokuCommunity/vscode-brightscript-language/pull/473))
-    - Fix crash during launch due to missing rale option ([PR #476](https://github.com/RokuCommunity/vscode-brightscript-language/pull/476))
-    - Fix wsl rdb bugs ([PR #478](https://github.com/RokuCommunity/vscode-brightscript-language/pull/478))
-    - Fix small lint issues ([PR #479](https://github.com/RokuCommunity/vscode-brightscript-language/pull/479))
+
+-   [@cewert (Charles Ewert)](https://github.com/cewert)
+    -   Fix build badge ([PR #474](https://github.com/RokuCommunity/vscode-brightscript-language/pull/474))
+-   [@jean-guyrivard (Jean-Guy Rivard)](https://github.com/jean-guyrivard)
+    -   Added validation for raleTrackerTaskFileLocation setting existence. ([PR #472](https://github.com/RokuCommunity/vscode-brightscript-language/pull/472))
+-   [@triwav (Brian Leighty)](https://github.com/triwav)
+    -   Run find node calculations in webview and other improvements ([PR #477](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Wrap the dnsLookup for host in a try/catch ([PR #473](https://github.com/RokuCommunity/vscode-brightscript-language/pull/473))
+    -   Fix crash during launch due to missing rale option ([PR #476](https://github.com/RokuCommunity/vscode-brightscript-language/pull/476))
+    -   Fix wsl rdb bugs ([PR #478](https://github.com/RokuCommunity/vscode-brightscript-language/pull/478))
+    -   Fix small lint issues ([PR #479](https://github.com/RokuCommunity/vscode-brightscript-language/pull/479))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix namespace-relative items ([PR #789](https://github.com/RokuCommunity/brighterscript/pull/789))
-    - Fix namespace-relative enum value ([PR #793](https://github.com/RokuCommunity/brighterscript/pull/793))
-    - Fix benchmark crashes ([PR #795](https://github.com/RokuCommunity/brighterscript/pull/795))
-    - Add cpuprofile ability to the benchmarks ([PR #796](https://github.com/RokuCommunity/brighterscript/pull/796))
-    - Improves performance in symbol table fetching ([PR #797](https://github.com/RokuCommunity/brighterscript/pull/797))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix namespace-relative items ([PR #789](https://github.com/RokuCommunity/brighterscript/pull/789))
+    -   Fix namespace-relative enum value ([PR #793](https://github.com/RokuCommunity/brighterscript/pull/793))
+    -   Fix benchmark crashes ([PR #795](https://github.com/RokuCommunity/brighterscript/pull/795))
+    -   Add cpuprofile ability to the benchmarks ([PR #796](https://github.com/RokuCommunity/brighterscript/pull/796))
+    -   Improves performance in symbol table fetching ([PR #797](https://github.com/RokuCommunity/brighterscript/pull/797))
 
 Contributions to [roku-deploy](https://github.com/RokuCommunity/roku-deploy):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix build status badge ([ad2c9ec](https://github.com/RokuCommunity/roku-deploy/commit/ad2c9ec))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix build status badge ([ad2c9ec](https://github.com/RokuCommunity/roku-deploy/commit/ad2c9ec))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@sethmaclean (sethmaclean)](https://github.com/sethmaclean)
-    - adds device query info to debug session ([PR #130](https://github.com/RokuCommunity/roku-debug/pull/130))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Exclude sourcemaps when sideloading ([PR #145](https://github.com/RokuCommunity/roku-debug/pull/145))
-    - Add better error for failed session starts ([PR #147](https://github.com/RokuCommunity/roku-debug/pull/147))
-    - Make axios a prod dependency ([PR #148](https://github.com/RokuCommunity/roku-debug/pull/148))
+
+-   [@sethmaclean (sethmaclean)](https://github.com/sethmaclean)
+    -   adds device query info to debug session ([PR #130](https://github.com/RokuCommunity/roku-debug/pull/130))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Exclude sourcemaps when sideloading ([PR #145](https://github.com/RokuCommunity/roku-debug/pull/145))
+    -   Add better error for failed session starts ([PR #147](https://github.com/RokuCommunity/roku-debug/pull/147))
+    -   Make axios a prod dependency ([PR #148](https://github.com/RokuCommunity/roku-debug/pull/148))
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
- - [@taschmidt (Tim Schmidt)](https://github.com/taschmidt)
-    - fix: do not consider consts as unused variables ([PR #85](https://github.com/RokuCommunity/bslint/pull/85))
+
+-   [@taschmidt (Tim Schmidt)](https://github.com/taschmidt)
+    -   fix: do not consider consts as unused variables ([PR #85](https://github.com/RokuCommunity/bslint/pull/85))

--- a/src/pages/whats-new/2023-04-April.md
+++ b/src/pages/whats-new/2023-04-April.md
@@ -16,7 +16,7 @@ Last month we introduced the new [Device View](https://rokucommunity.github.io/w
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/f5c85fea-9e3e-46ec-89cb-cfc180f1c033)
 
 
-In addition to the WSL fixes, we also made a few [performance improvements](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477) and [UI tweaks](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477) to the SceneGraph Inspector that should make it nicer to use. 
+In addition to the WSL fixes, we also made a few [performance improvements](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477) and [UI tweaks](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477) to the SceneGraph Inspector that should make it nicer to use.
 
 ## Small language server performance boost
 [brighterscript#797](https://github.com/RokuCommunity/brighterscript/pull/797) adds a small performance boost to the language server by optimizing the `AstNode.getSymbolTable()` method. There are no changes to the way you code, but enjoy the free speed boost! This is available starting in [BrighterScript v0.64.3](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0643---2023-04-28) and [BrightScript Language extension for VSCode v2.40.1](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2401---2023-04-28)
@@ -25,7 +25,7 @@ Before:
 
 ![image](https://user-images.githubusercontent.com/2544493/233732854-1577e2c5-e2eb-489b-b49e-9c5464b97e04.png)
 
-After: 
+After:
 
 ![image](https://user-images.githubusercontent.com/2544493/233732843-42f08221-45de-49ea-99b7-1707567ac1f8.png)
 
@@ -33,11 +33,11 @@ After:
 # Debugging
 
 ## Exclude sourcemaps when sideloading
-Many preprocessors such as BrighterScript or gulp plugins will generate sourcemaps alongside the generated files, which are a way to link a generated file, line, and column location back to its original location. The BrightScript language extension for VSCode fully supports reading these sourcemaps to improve the debugging experience with projects that leverage a preprocessor. However, sourcemaps are fairly large, sometimes even as large as the generated file itself. 
+Many preprocessors such as BrighterScript or gulp plugins will generate sourcemaps alongside the generated files, which are a way to link a generated file, line, and column location back to its original location. The BrightScript language extension for VSCode fully supports reading these sourcemaps to improve the debugging experience with projects that leverage a preprocessor. However, sourcemaps are fairly large, sometimes even as large as the generated file itself.
 
 ![image](https://github.com/rokucommunity/rokucommunity.github.io/assets/2544493/c5a172a3-fec3-4035-9ae3-669a43858298)
 
-Also, it seems that on-Roku compile times are slower anytiime sourcemaps are present (perhaps the Roku tries to parse the sourcemaps?), which results in measurably longer on-device compile times. 
+Also, it seems that on-Roku compile times are slower anytiime sourcemaps are present (perhaps the Roku tries to parse the sourcemaps?), which results in measurably longer on-device compile times.
 
 Thanks to [roku-debug#145](https://github.com/RokuCommunity/roku-debug/pull/145), the BrightScript Language extension for VSCode will now exclude sourceamps from sideloaded zips starting in [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0) . This speeds up zip times, upload times, _and_ compile times. Here are some timing results from a large brighterscript app. The results speak for themselves:
 
@@ -58,29 +58,29 @@ Packaging projects took: 2s411ms, Uploading zip took 5920ms, AppCompileComplete 
 ```
 
 ## Better error handling for RALE integration
-The BrightScript Language extension for VSCode has basic support for [RALE integration](https://rokucommunity.github.io/vscode-brightscript-language/Debugging/rale.html). When enabled, the extension can auto-inject the RALE tracker task init code into your project by replacing a specific comment with the tracker task init logic. However, there was a bug where the debug session would crash with a very obscure message if `injectRaleTrackerTask` was enabled but the file at `raleTrackerTaskFileLocation` was missing or the property was omitted entirely. 
+The BrightScript Language extension for VSCode has basic support for [RALE integration](https://rokucommunity.github.io/vscode-brightscript-language/Debugging/rale.html). When enabled, the extension can auto-inject the RALE tracker task init code into your project by replacing a specific comment with the tracker task init logic. However, there was a bug where the debug session would crash with a very obscure message if `injectRaleTrackerTask` was enabled but the file at `raleTrackerTaskFileLocation` was missing or the property was omitted entirely.
 
-As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0), this flow has been improved to now show a much more helpful error notification. 
+As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0), this flow has been improved to now show a much more helpful error notification.
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/414beed6-54d5-4556-9120-19a664c9d083)
 
 ## Better error reporting for launch.json validation crashes
-At the start of a debug session in VSCode, the BrightScript Language extension will validate and sanitize the selected `launch.json` configuration. Sometimes a runtime exception can occur during this process. In the past, these crash stack traces weren't avaiable to the developer. As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0), the entire launch config validation flow is now wrapped in a `try`/`catch` so we can log exceptions to the output channel, which should give developers access to much more useful feedback for future crashes. 
+At the start of a debug session in VSCode, the BrightScript Language extension will validate and sanitize the selected `launch.json` configuration. Sometimes a runtime exception can occur during this process. In the past, these crash stack traces weren't avaiable to the developer. As of vscode extension [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/compare/v2.39.0...v2.40.0), the entire launch config validation flow is now wrapped in a `try`/`catch` so we can log exceptions to the output channel, which should give developers access to much more useful feedback for future crashes.
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/bd6fcaae-cf7e-4cff-b07d-de53196ca266)
 
 
 ## Add better error for failed session starts
-If you've been using the vscode extension for a while now, you've probably encountered situations where the debug session just randomly shuts down, with no warning or explanation. Starting in release [v2.40.1](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2401---2023-04-28), many of these crashes will now show a much more helpful error popup. 
+If you've been using the vscode extension for a while now, you've probably encountered situations where the debug session just randomly shuts down, with no warning or explanation. Starting in release [v2.40.1](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2401---2023-04-28), many of these crashes will now show a much more helpful error popup.
 
 ## Wrap the dnsLookup for host in a try/catch
-Rather than trying to remember several different IP addresses, another way of referencing your Rokus is by DNS name. Many routers allow statically assigning a host name to a device on the network. For example, Roku 192.168.1.25 could be given the name "`roku-streaming-stick1`". At the start of a debug session, the vscode extension will do a DNS lookup and translate that DNS name back to its local IP address. 
+Rather than trying to remember several different IP addresses, another way of referencing your Rokus is by DNS name. Many routers allow statically assigning a host name to a device on the network. For example, Roku 192.168.1.25 could be given the name "`roku-streaming-stick1`". At the start of a debug session, the vscode extension will do a DNS lookup and translate that DNS name back to its local IP address.
 
 However, in some situations, that DNS lookup could fail, and we were not properly handling that failure and instead would crash the debug session. This has been fixed in [v2.40.0](https://github.com/rokucommunity/vscode-brightscript-language/blob/master/CHANGELOG.md#2400---2023-04-18) of the BrightScript Language extension for VSCode so that, if the DNS lookup fails, we'll attempt to use the DNS name as-is, which sometimes still works.
 
 # BrighterScript
 ## bslint now works with `const`
-If you've used the `const` feature in BrighterScript (introduced in [v0.53.0](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0530---2022-07-14)) and also [bslint](https://github.com/rokucommunity/bslint), you may have noticed that bslint would incorrectly show errors whenever you tried to reference those consts. 
+If you've used the `const` feature in BrighterScript (introduced in [v0.53.0](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0530---2022-07-14)) and also [bslint](https://github.com/rokucommunity/bslint), you may have noticed that bslint would incorrectly show errors whenever you tried to reference those consts.
 
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/c63000da-3316-400a-aebf-bf0bc3484f63)
 
@@ -89,19 +89,19 @@ This has been fixed and is available starting in [bslint v0.8.3](https://github.
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/bcd949c0-1b09-4552-b42b-6dd612e55a31)
 
 ## Fix namespace-inferred items
-BrighterScript has a feature in nested namespaces where all the items in that same namespace can be referenced _without_ needing to include the full leading namespace part. We call this "namespace inference", which you can read about [here](https://github.com/rokucommunity/brighterscript/blob/master/docs/namespaces.md#namespace-inference). As a result of supporting this feature, certain names become unavailable for use as variable identifiers when they conflict with inferred namespace names. These variables are now properly flagged as errors starting in BrighterScript [v0.64.0](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0640---2023-04-04). 
+BrighterScript has a feature in nested namespaces where all the items in that same namespace can be referenced _without_ needing to include the full leading namespace part. We call this "namespace inference", which you can read about [here](https://github.com/rokucommunity/brighterscript/blob/master/docs/namespaces.md#namespace-inference). As a result of supporting this feature, certain names become unavailable for use as variable identifiers when they conflict with inferred namespace names. These variables are now properly flagged as errors starting in BrighterScript [v0.64.0](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0640---2023-04-04).
 
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/5da43e85-9695-41e8-849e-3cc8b699d428)
 
 ## Fix semantic tokens for namespaces
-Semantic tokens are a way for the language server to enhance syntax highlighting for certain tokens, based on more complex language semantics that regex-based textmate grammar syntax highlighting isn't capable of supporting. We've fixed several bugs in bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...v0.64.0) related to namespace semantic tokens when they're used in assignment statements and function parameters. 
+Semantic tokens are a way for the language server to enhance syntax highlighting for certain tokens, based on more complex language semantics that regex-based textmate grammar syntax highlighting isn't capable of supporting. We've fixed several bugs in bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...v0.64.0) related to namespace semantic tokens when they're used in assignment statements and function parameters.
 
 TL;DR: namespaces are prettier now!
 
 ![image](https://github.com/rokucommunity/brighterscript/assets/2544493/1da1f188-b224-40bc-bd03-0bd578f5a21b)
 
 
-## Fix namespace-inferred enum value 
+## Fix namespace-inferred enum value
 BrighterScript [v0.64.2](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0642---2023-04-18) fixed a validation bug that was incorrectly flagging namespace-inferred enum values as errors.
 
 **Before:**
@@ -123,14 +123,14 @@ bsc [v0.64.0](https://github.com/rokucommunity/brighterscript/compare/v0.63.0...
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/549f1b74-bfcf-40a6-82d5-214476783bd8)
 
 ## Type tracking coming soon
-[markwpearce (Mark Pearce)](https://github.com/markwpearce) has been making incredible progress on type tracking and validation in BrighterScript. We're currently working on improving its performance. The validation flow has slowed down significantly as a result of all the new type tracking goodness we're running, but we have some ideas on how to gain back most of that performance so stay tuned. 
+[markwpearce (Mark Pearce)](https://github.com/markwpearce) has been making incredible progress on type tracking and validation in BrighterScript. We're currently working on improving its performance. The validation flow has slowed down significantly as a result of all the new type tracking goodness we're running, but we have some ideas on how to gain back most of that performance so stay tuned.
 
-Also, for BrighterScript Plugin authors, be aware that there are some **BREAKING CHANGES** coming to the BrightScript AST. We've tried to keep them as minimal as possible and we hope to release them all at the same time when type tracking lands in the next month or two so that you can fix all of the errors at the same time. We'll provide a full writeup of the changes once the feature lands. 
+Also, for BrighterScript Plugin authors, be aware that there are some **BREAKING CHANGES** coming to the BrightScript AST. We've tried to keep them as minimal as possible and we hope to release them all at the same time when type tracking lands in the next month or two so that you can fix all of the errors at the same time. We'll provide a full writeup of the changes once the feature lands.
 
 Here are a few examples of some new validations that are coming soon:
 ![image](https://github.com/rokucommunity/roku-deploy/assets/2544493/55d2f230-18d2-4948-bb97-2fc429a26bf5)
 
-You can follow our progress on type tracking in [BrighterScript#783](https://github.com/rokucommunity/brighterscript/pull/783). 
+You can follow our progress on type tracking in [BrighterScript#783](https://github.com/rokucommunity/brighterscript/pull/783).
 
 # Misc
 ## Fix some more github status badges
@@ -144,45 +144,40 @@ You can follow our progress on type tracking in [BrighterScript#783](https://git
 For developers who work on the BrighterScript compiler, we have a handy benchmarking tool that helps compare the current performance against the latest release.  ([#796](https://github.com/RokuCommunity/brighterscript/pull/796)) adds a `--profile` cli flag that will generate a `.cpuprofile` file that can be used to identify [hot spots](https://en.wikipedia.org/wiki/Hot_spot_(computer_programming)) that need to be optimized. We also fixed some stability issues in the benchmark project ([#795](https://github.com/RokuCommunity/brighterscript/pull/795))
 
 # Thank you
-
 Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
 
-Contributions to this month's whats-new:
- - [@philanderson888 (Phil Anderson)](https://github.com/philanderson888)
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - Run find node calculations in webview and other improvements ([PR #477](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix crash during launch due to missing rale option ([PR #476](https://github.com/RokuCommunity/vscode-brightscript-language/pull/476))
-    - Wrap the dnsLookup for host in a try/catch ([PR #473](https://github.com/RokuCommunity/vscode-brightscript-language/pull/473))
-    - Fix small lint issues ([PR #479](https://github.com/RokuCommunity/vscode-brightscript-language/pull/479))
-    - Fix wsl rdb bugs ([PR #478](https://github.com/RokuCommunity/vscode-brightscript-language/pull/478))
  - [@cewert (Charles Ewert)](https://github.com/cewert)
     - Fix build badge ([PR #474](https://github.com/RokuCommunity/vscode-brightscript-language/pull/474))
  - [@jean-guyrivard (Jean-Guy Rivard)](https://github.com/jean-guyrivard)
     - Added validation for raleTrackerTaskFileLocation setting existence. ([PR #472](https://github.com/RokuCommunity/vscode-brightscript-language/pull/472))
+ - [@triwav (Brian Leighty)](https://github.com/triwav)
+    - Run find node calculations in webview and other improvements ([PR #477](https://github.com/RokuCommunity/vscode-brightscript-language/pull/477))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Wrap the dnsLookup for host in a try/catch ([PR #473](https://github.com/RokuCommunity/vscode-brightscript-language/pull/473))
+    - Fix crash during launch due to missing rale option ([PR #476](https://github.com/RokuCommunity/vscode-brightscript-language/pull/476))
+    - Fix wsl rdb bugs ([PR #478](https://github.com/RokuCommunity/vscode-brightscript-language/pull/478))
+    - Fix small lint issues ([PR #479](https://github.com/RokuCommunity/vscode-brightscript-language/pull/479))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Fix namespace-relative items ([PR #789](https://github.com/RokuCommunity/brighterscript/pull/789))
     - Fix namespace-relative enum value ([PR #793](https://github.com/RokuCommunity/brighterscript/pull/793))
-    - Improves performance in symbol table fetching ([PR #797](https://github.com/RokuCommunity/brighterscript/pull/797))
-    - Add cpuprofile ability to the benchmarks ([PR #796](https://github.com/RokuCommunity/brighterscript/pull/796))
     - Fix benchmark crashes ([PR #795](https://github.com/RokuCommunity/brighterscript/pull/795))
- 
+    - Add cpuprofile ability to the benchmarks ([PR #796](https://github.com/RokuCommunity/brighterscript/pull/796))
+    - Improves performance in symbol table fetching ([PR #797](https://github.com/RokuCommunity/brighterscript/pull/797))
+
 Contributions to [roku-deploy](https://github.com/RokuCommunity/roku-deploy):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Fix build status badge ([ad2c9ec](https://github.com/RokuCommunity/roku-deploy/commit/ad2c9ec))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
+ - [@sethmaclean (sethmaclean)](https://github.com/sethmaclean)
+    - adds device query info to debug session ([PR #130](https://github.com/RokuCommunity/roku-debug/pull/130))
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Exclude sourcemaps when sideloading ([PR #145](https://github.com/RokuCommunity/roku-debug/pull/145))
     - Add better error for failed session starts ([PR #147](https://github.com/RokuCommunity/roku-debug/pull/147))
     - Make axios a prod dependency ([PR #148](https://github.com/RokuCommunity/roku-debug/pull/148))
- - [@sethmaclean (sethmaclean)](https://github.com/sethmaclean)
-    - adds device query info to debug session ([PR #130](https://github.com/RokuCommunity/roku-debug/pull/130))
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
  - [@taschmidt (Tim Schmidt)](https://github.com/taschmidt)

--- a/src/pages/whats-new/2023-05-May.md
+++ b/src/pages/whats-new/2023-05-May.md
@@ -6,7 +6,7 @@ layout: ../../layouts/WhatsNewPost.astro
 
 # Overview
 
-This month we fixed that pesky `EXIST: file already exists, mkdir...` error that was crashing debug sessions, added node.js v19 compatibility for roku-deploy, several quality of life fixes for various RokuCommunity projects, and more. 
+This month we fixed that pesky `EXIST: file already exists, mkdir...` error that was crashing debug sessions, added node.js v19 compatibility for roku-deploy, several quality of life fixes for various RokuCommunity projects, and more.
 
 We've also added a new section to this writeup, called [Issue of the month](#issue-of-the-month). Check it out!
 
@@ -24,9 +24,9 @@ The RokuCommunity projects are maintained by a relatively small group of develop
 ## Issue of the month
 In this section, we highlight a specific issue where we could benefit from the community's assistance in finding a solution. These problems are generally straightforward to address, and serve as an excellent opportunity to become acquainted with the RokuCommunity codebases.
 
-This month, we'd like to draw attention to [vscode-brightscript-language#437: Add button to copy device IP](https://github.com/rokucommunity/vscode-brightscript-language/issues/437). 
+This month, we'd like to draw attention to [vscode-brightscript-language#437: Add button to copy device IP](https://github.com/rokucommunity/vscode-brightscript-language/issues/437).
 
-The `Devices` panel shows many different fields from the `device-info` ECP request. Clicking on any of these items will automatically copy the value to your clipboard, which is super helpful. However, one exception is the `IP address` entry, which when clicked will open the Roku developer upload form instead of copying the IP address to your clipboard. We'd like to update that functionality so that clicking the IP address copies the value to your clipboard, and there would be a secondary link or button that opens the developer portal. 
+The `Devices` panel shows many different fields from the `device-info` ECP request. Clicking on any of these items will automatically copy the value to your clipboard, which is super helpful. However, one exception is the `IP address` entry, which when clicked will open the Roku developer upload form instead of copying the IP address to your clipboard. We'd like to update that functionality so that clicking the IP address copies the value to your clipboard, and there would be a secondary link or button that opens the developer portal.
 
 ![image](https://github.com/rokucommunity/bslint/assets/2544493/4bd0b0f1-8927-41a1-9c88-1b483173c94f)
 
@@ -50,24 +50,24 @@ After:
 # Debugging
 
 ## Fix `file already exists` crash when starting debug sessions
-We fixed a critical debugger issue that would show an error `EXIST: file already exists, mkdir...` anytime you ran a debug session, requiring require a full system restart or force-quitting many of the vscode processes. The problem was introduced 
-in [v0.18.7](https://github.com/rokucommunity/roku-debug/blob/master/CHANGELOG.md#0187---2023-04-28) when we improved the error messaging around certain types of debug session failures (ironic, right?). 
+We fixed a critical debugger issue that would show an error `EXIST: file already exists, mkdir...` anytime you ran a debug session, requiring require a full system restart or force-quitting many of the vscode processes. The problem was introduced
+in [v0.18.7](https://github.com/rokucommunity/roku-debug/blob/master/CHANGELOG.md#0187---2023-04-28) when we improved the error messaging around certain types of debug session failures (ironic, right?).
 
 The actual problem is that the `.shutdown()` call in the debug session fell into an infinite async loop, causing the stagingDir to be regularly locked by the OS as we repeatedly tried to empty its contents. To solve this, we now guard the `.shutdown()` call in a promise semaphore so we can only run shutdown once, the first time called. See [#152](https://github.com/RokuCommunity/roku-debug/pull/152) for more information.
- 
+
 ## Rendezvous Panel `hitCount` math fix
 We fixed a math error in the `hitCount` counter in the top-level groups of the Rendezvous panel of the vscode extension. That number should now properly match the sum of all the child hit counts!
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/7cdfc65b-62c1-4260-b9fa-2ef8019ac1a1)
 
-## Fixed infinite recursion possibility in the SceneGraph Inspector 
-We've fixed a bug that could sometimes cause infinite recursion when using the Scenegraph Inspector.  See [vscode-brightscript-language#480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480) for more details. There's not really anything to show, so here's a photo of the SceneGraph Inspector just for fun. 
+## Fixed infinite recursion possibility in the SceneGraph Inspector
+We've fixed a bug that could sometimes cause infinite recursion when using the Scenegraph Inspector.  See [vscode-brightscript-language#480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480) for more details. There's not really anything to show, so here's a photo of the SceneGraph Inspector just for fun.
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/c2dd1ec7-09e0-4487-a0bb-4f5c50dc3a97)
 
 
 ## Augment hex error codes with text descriptions
-Whenever you encounter a runtime crash during a debug session, the device often will include a hexadecimal error code (such as `&h08`). These error codes are not overly helpful at a glance unless you've memorized all of Roku's error codes. To improve readability of these crashlogs, the BrightScript Language extension for vscode now augments those hex codes with more useful error information. 
+Whenever you encounter a runtime crash during a debug session, the device often will include a hexadecimal error code (such as `&h08`). These error codes are not overly helpful at a glance unless you've memorized all of Roku's error codes. To improve readability of these crashlogs, the BrightScript Language extension for vscode now augments those hex codes with more useful error information.
 
 **Before:**
 
@@ -90,7 +90,7 @@ Many new commands have been added to the **Roku Commands** panel in the vscode e
 ## Plugin API: Fixes for `findChild` and `findAncestor`
 We have improved the `AstNode` methods `findChild` and `findAncestor` methods to support:
 
-- **externally cancelling the walk**. If possible, you should consider cancelling the walk once you find the node you're looking for, as this will improve performance by skipping wasted walking 
+- **externally cancelling the walk**. If possible, you should consider cancelling the walk once you find the node you're looking for, as this will improve performance by skipping wasted walking
 
 - **enabling findAncestor to return a different node than matched, if the matcher returns the node**
 
@@ -104,56 +104,52 @@ You can now use roku-deploy on Node.js v19 and above! The core issue was caused 
 ## Goodbye `request`, hello `postman-request`
 For several years the RokuCommunity tools like roku-deploy and roku-debug have been using the [request](https://www.npmjs.com/package/request) library for our http request needs. However, the request package [was deprecated in 2019](https://github.com/request/request/issues/3142) and has started triggering all sorts of npm audit issues. Since the `request` package still perfectly suits our needs, we've migrated to a fork of the project called [postman-request](https://www.npmjs.com/package/postman-request) which is actively maintained.
 
-On a related note, a few recent pull requests had added a dependency on [axios](https://www.npmjs.com/package/axios). In order to keep our projects smaller, we've removed that dependency in favor of leveraging [postman-request](https://www.npmjs.com/package/postman-request) in those situations as well. 
+On a related note, a few recent pull requests had added a dependency on [axios](https://www.npmjs.com/package/axios). In order to keep our projects smaller, we've removed that dependency in favor of leveraging [postman-request](https://www.npmjs.com/package/postman-request) in those situations as well.
 
-None of these changes should have any impact on your direct use of the tools, but if you have Node.js scripts or BrighterScript plugins that utilize [request](https://www.npmjs.com/package/request) as a transient dependency from our tools, you'll now need to install `request` directly or change to importing [postman-request](https://www.npmjs.com/package/postman-request) instead, as [request](https://www.npmjs.com/package/request) will no longer be present in node_modules. 
+None of these changes should have any impact on your direct use of the tools, but if you have Node.js scripts or BrighterScript plugins that utilize [request](https://www.npmjs.com/package/request) as a transient dependency from our tools, you'll now need to install `request` directly or change to importing [postman-request](https://www.npmjs.com/package/postman-request) instead, as [request](https://www.npmjs.com/package/request) will no longer be present in node_modules.
 
 
 ## Fixed roku-deploy device tests
-If you've contributed to roku-deploy in the past, you might have noticed that some of the device tests were failing. This was because we had accidentally replaced our `signingPackage.pkg` with an empty file (oops!). Turns out one of our unit tests was using the wrong directory and was replacing the file on every test suite run. That's been fixed and the correct `signingPackage.pkg` file has been restored, so those device tests should now work properly moving forward. 
+If you've contributed to roku-deploy in the past, you might have noticed that some of the device tests were failing. This was because we had accidentally replaced our `signingPackage.pkg` with an empty file (oops!). Turns out one of our unit tests was using the wrong directory and was replacing the file on every test suite run. That's been fixed and the correct `signingPackage.pkg` file has been restored, so those device tests should now work properly moving forward.
 
 # Thank you
-
 Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
+ - [@MilapNaik (Milap Naik)](https://github.com/MilapNaik)
+    - Change rendezvous count for file history ([PR #482](https://github.com/RokuCommunity/vscode-brightscript-language/pull/482))
+ - [@philanderson888 (Phil Anderson)](https://github.com/philanderson888)
+    - Roku Error Codes ([PR #467](https://github.com/RokuCommunity/vscode-brightscript-language/pull/467))
+ - [@triwav (Brian Leighty)](https://github.com/triwav)
+    - fix infinite recursion possibility in Scenegraph Inspector and fix Roku Commands list of available requests ([PR #480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480))
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Remove `<` and `>` from bracket matching ([PR #483](https://github.com/RokuCommunity/vscode-brightscript-language/pull/483))
     - Use postman-request instead of request ([PR #485](https://github.com/RokuCommunity/vscode-brightscript-language/pull/485))
- - [@MilapNaik (Milap Naik)](https://github.com/MilapNaik)
-    - Change rendezvous count for file history ([PR #482](https://github.com/RokuCommunity/vscode-brightscript-language/pull/482))
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - fix infinite recursion possibility in Scenegraph Inspector and fix Roku Commands list of available requests ([PR #480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480))
- - [@dependabot[bot] (dependabot[bot])](https://github.com/apps/dependabot)
-    - Bump http-cache-semantics from 4.1.0 to 4.1.1 ([PR #466](https://github.com/RokuCommunity/vscode-brightscript-language/pull/466))
- - [@philanderson888 (Phil Anderson)](https://github.com/philanderson888)
-    - Roku Error Codes ([PR #467](https://github.com/RokuCommunity/vscode-brightscript-language/pull/467))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
  - [@cewert (Charles Ewert)](https://github.com/cewert)
     - Fix code formatting ([PR #805](https://github.com/RokuCommunity/brighterscript/pull/805))
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Update README.md ([PR #804](https://github.com/RokuCommunity/brighterscript/pull/804))
-    - npm audit fixes. upgrade to coveralls-next ([43756d8](https://github.com/RokuCommunity/brighterscript/commit/43756d8))
     - Improve findChild and findAncestor AST methods ([PR #807](https://github.com/RokuCommunity/brighterscript/pull/807))
+    - npm audit fixes. upgrade to coveralls-next ([43756d8](https://github.com/RokuCommunity/brighterscript/commit/43756d8))
 
 Contributions to [roku-deploy](https://github.com/RokuCommunity/roku-deploy):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix audit issues ([PR #116](https://github.com/RokuCommunity/roku-deploy/pull/116))
-    - Fix bug that overwrites signing pkg during tests ([PR #114](https://github.com/RokuCommunity/roku-deploy/pull/114))
-    - Fix broken device tests ([fefe375](https://github.com/RokuCommunity/roku-deploy/commit/fefe375))
  - [@fumer-fubotv (fumer-fubotv)](https://github.com/fumer-fubotv)
     - TBD-67: roku-deploy: fix nodejs 19 bug ([PR #115](https://github.com/RokuCommunity/roku-deploy/pull/115))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Fix broken device tests ([fefe375](https://github.com/RokuCommunity/roku-deploy/commit/fefe375))
+    - Fix bug that overwrites signing pkg during tests ([PR #114](https://github.com/RokuCommunity/roku-deploy/pull/114))
+    - Fix audit issues ([PR #116](https://github.com/RokuCommunity/roku-deploy/pull/116))
 
 Contributions to [logger](https://github.com/RokuCommunity/logger):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix dependencies ([04af7a0](https://github.com/RokuCommunity/logger/commit/04af7a0))
-    - Fix workflow build link ([b851603](https://github.com/RokuCommunity/logger/commit/b851603))
-    - Merge branch 'master' of https://github.com/rokucommunity/logger ([cf0ed74](https://github.com/RokuCommunity/logger/commit/cf0ed74))
     - Fix build status badge ([b1e490b](https://github.com/RokuCommunity/logger/commit/b1e490b))
+    - Fix workflow build link ([b851603](https://github.com/RokuCommunity/logger/commit/b851603))
+    - Fix dependencies ([04af7a0](https://github.com/RokuCommunity/logger/commit/04af7a0))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - Fix crash by using postman-request ([PR #151](https://github.com/RokuCommunity/roku-debug/pull/151))
-    - Remove axios in favor of postman-request ([PR #153](https://github.com/RokuCommunity/roku-debug/pull/153))
     - Fix `file already exists` error and hung process ([PR #152](https://github.com/RokuCommunity/roku-debug/pull/152))
+    - Remove axios in favor of postman-request ([PR #153](https://github.com/RokuCommunity/roku-debug/pull/153))

--- a/src/pages/whats-new/2023-05-May.md
+++ b/src/pages/whats-new/2023-05-May.md
@@ -13,15 +13,17 @@ We've also added a new section to this writeup, called [Issue of the month](#iss
 ## We need your help
 
 The RokuCommunity projects are maintained by a relatively small group of developers (mostly volunteers), and we have a growing list of of unresolved issues. We need your help! There are many different ways you can contribute. Whether it's addressing bugs, improving documentation, introducing new features, or simply helping us manage our expanding list of GitHub issues, your involvement would be greatly appreciated. We are more than happy to guide you in finding the most suitable contribution method that aligns with your interests. To learn more about how you can contribute, feel free to reach out to us on [Slack](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA), or explore the existing GitHub issues:
-- [vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language/issues)
-- [brighterscript](https://github.com/rokucommunity/brighterscript/issues)
-- [brighterscript-formatter](https://github.com/rokucommunity/brighterscript-formatter/issues)
-- [roku-deploy](https://github.com/rokucommunity/roku-deploy/issues)
-- [roku-debug](https://github.com/rokucommunity/roku-debug/issues)
-- [bslint](https://github.com/rokucommunity/bslint/issues)
-- [ropm](https://github.com/rokucommunity/ropm/issues)
+
+-   [vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language/issues)
+-   [brighterscript](https://github.com/rokucommunity/brighterscript/issues)
+-   [brighterscript-formatter](https://github.com/rokucommunity/brighterscript-formatter/issues)
+-   [roku-deploy](https://github.com/rokucommunity/roku-deploy/issues)
+-   [roku-debug](https://github.com/rokucommunity/roku-debug/issues)
+-   [bslint](https://github.com/rokucommunity/bslint/issues)
+-   [ropm](https://github.com/rokucommunity/ropm/issues)
 
 ## Issue of the month
+
 In this section, we highlight a specific issue where we could benefit from the community's assistance in finding a solution. These problems are generally straightforward to address, and serve as an excellent opportunity to become acquainted with the RokuCommunity codebases.
 
 This month, we'd like to draw attention to [vscode-brightscript-language#437: Add button to copy device IP](https://github.com/rokucommunity/vscode-brightscript-language/issues/437).
@@ -46,27 +48,29 @@ After:
 
 ![image](https://user-images.githubusercontent.com/2544493/238976432-63d8b84f-f91b-4aec-bc3a-4893677b4b5a.png)
 
-
 # Debugging
 
 ## Fix `file already exists` crash when starting debug sessions
+
 We fixed a critical debugger issue that would show an error `EXIST: file already exists, mkdir...` anytime you ran a debug session, requiring require a full system restart or force-quitting many of the vscode processes. The problem was introduced
 in [v0.18.7](https://github.com/rokucommunity/roku-debug/blob/master/CHANGELOG.md#0187---2023-04-28) when we improved the error messaging around certain types of debug session failures (ironic, right?).
 
 The actual problem is that the `.shutdown()` call in the debug session fell into an infinite async loop, causing the stagingDir to be regularly locked by the OS as we repeatedly tried to empty its contents. To solve this, we now guard the `.shutdown()` call in a promise semaphore so we can only run shutdown once, the first time called. See [#152](https://github.com/RokuCommunity/roku-debug/pull/152) for more information.
 
 ## Rendezvous Panel `hitCount` math fix
+
 We fixed a math error in the `hitCount` counter in the top-level groups of the Rendezvous panel of the vscode extension. That number should now properly match the sum of all the child hit counts!
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/7cdfc65b-62c1-4260-b9fa-2ef8019ac1a1)
 
 ## Fixed infinite recursion possibility in the SceneGraph Inspector
-We've fixed a bug that could sometimes cause infinite recursion when using the Scenegraph Inspector.  See [vscode-brightscript-language#480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480) for more details. There's not really anything to show, so here's a photo of the SceneGraph Inspector just for fun.
+
+We've fixed a bug that could sometimes cause infinite recursion when using the Scenegraph Inspector. See [vscode-brightscript-language#480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480) for more details. There's not really anything to show, so here's a photo of the SceneGraph Inspector just for fun.
 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/c2dd1ec7-09e0-4487-a0bb-4f5c50dc3a97)
 
-
 ## Augment hex error codes with text descriptions
+
 Whenever you encounter a runtime crash during a debug session, the device often will include a hexadecimal error code (such as `&h08`). These error codes are not overly helpful at a glance unless you've memorized all of Roku's error codes. To improve readability of these crashlogs, the BrightScript Language extension for vscode now augments those hex codes with more useful error information.
 
 **Before:**
@@ -76,80 +80,90 @@ Syntax Error. (compile error &h02) in pkg:/source/main.brs(3)
 ```
 
 **After:**
+
 ```bash
 Syntax Error. (compile error &h02 (ERR_SYNTAX): syntax error ) in pkg:/source/main.brs(3)
 ```
 
 ## Added missing Roku Commands options
+
 Many new commands have been added to the **Roku Commands** panel in the vscode extension. We won't get into listing them all here, but if you're a regular user of this feature then you'll appreciate these new commands! Here's a screenshot of that **Roku Commands** panel in vscode.
 ![image](https://github.com/rokucommunity/roku-debug/assets/2544493/49dc6737-6fba-4f7b-9e9c-ed3056bdd032)
-
 
 # BrighterScript
 
 ## Plugin API: Fixes for `findChild` and `findAncestor`
+
 We have improved the `AstNode` methods `findChild` and `findAncestor` methods to support:
 
-- **externally cancelling the walk**. If possible, you should consider cancelling the walk once you find the node you're looking for, as this will improve performance by skipping wasted walking
+-   **externally cancelling the walk**. If possible, you should consider cancelling the walk once you find the node you're looking for, as this will improve performance by skipping wasted walking
 
-- **enabling findAncestor to return a different node than matched, if the matcher returns the node**
+-   **enabling findAncestor to return a different node than matched, if the matcher returns the node**
 
 # Misc
 
 ## roku-deploy support for Node.js v19
+
 You can now use roku-deploy on Node.js v19 and above! The core issue was caused by Node.js 19 changing the default keepalive settings on its internal http library. As such, roku-deploy on node 19 would fail with an `ECONNRESET` error. The fix was to pass in an [additional argument](https://github.com/rokucommunity/roku-deploy/pull/115/files#diff-a8b623936bbdbb88641b6873c33b914effcaf216de11b9a3c36d039322cd35f4R386) to the [postman-request](https://www.npmjs.com/package/postman-request) `agentOptions`.
 
 # For Contributors
 
 ## Goodbye `request`, hello `postman-request`
+
 For several years the RokuCommunity tools like roku-deploy and roku-debug have been using the [request](https://www.npmjs.com/package/request) library for our http request needs. However, the request package [was deprecated in 2019](https://github.com/request/request/issues/3142) and has started triggering all sorts of npm audit issues. Since the `request` package still perfectly suits our needs, we've migrated to a fork of the project called [postman-request](https://www.npmjs.com/package/postman-request) which is actively maintained.
 
 On a related note, a few recent pull requests had added a dependency on [axios](https://www.npmjs.com/package/axios). In order to keep our projects smaller, we've removed that dependency in favor of leveraging [postman-request](https://www.npmjs.com/package/postman-request) in those situations as well.
 
 None of these changes should have any impact on your direct use of the tools, but if you have Node.js scripts or BrighterScript plugins that utilize [request](https://www.npmjs.com/package/request) as a transient dependency from our tools, you'll now need to install `request` directly or change to importing [postman-request](https://www.npmjs.com/package/postman-request) instead, as [request](https://www.npmjs.com/package/request) will no longer be present in node_modules.
 
-
 ## Fixed roku-deploy device tests
+
 If you've contributed to roku-deploy in the past, you might have noticed that some of the device tests were failing. This was because we had accidentally replaced our `signingPackage.pkg` with an empty file (oops!). Turns out one of our unit tests was using the wrong directory and was replacing the file on every test suite run. That's been fixed and the correct `signingPackage.pkg` file has been restored, so those device tests should now work properly moving forward.
 
 # Thank you
-Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
- - [@MilapNaik (Milap Naik)](https://github.com/MilapNaik)
-    - Change rendezvous count for file history ([PR #482](https://github.com/RokuCommunity/vscode-brightscript-language/pull/482))
- - [@philanderson888 (Phil Anderson)](https://github.com/philanderson888)
-    - Roku Error Codes ([PR #467](https://github.com/RokuCommunity/vscode-brightscript-language/pull/467))
- - [@triwav (Brian Leighty)](https://github.com/triwav)
-    - fix infinite recursion possibility in Scenegraph Inspector and fix Roku Commands list of available requests ([PR #480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Remove `<` and `>` from bracket matching ([PR #483](https://github.com/RokuCommunity/vscode-brightscript-language/pull/483))
-    - Use postman-request instead of request ([PR #485](https://github.com/RokuCommunity/vscode-brightscript-language/pull/485))
+
+-   [@MilapNaik (Milap Naik)](https://github.com/MilapNaik)
+    -   Change rendezvous count for file history ([PR #482](https://github.com/RokuCommunity/vscode-brightscript-language/pull/482))
+-   [@philanderson888 (Phil Anderson)](https://github.com/philanderson888)
+    -   Roku Error Codes ([PR #467](https://github.com/RokuCommunity/vscode-brightscript-language/pull/467))
+-   [@triwav (Brian Leighty)](https://github.com/triwav)
+    -   fix infinite recursion possibility in Scenegraph Inspector and fix Roku Commands list of available requests ([PR #480](https://github.com/RokuCommunity/vscode-brightscript-language/pull/480))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Remove `<` and `>` from bracket matching ([PR #483](https://github.com/RokuCommunity/vscode-brightscript-language/pull/483))
+    -   Use postman-request instead of request ([PR #485](https://github.com/RokuCommunity/vscode-brightscript-language/pull/485))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@cewert (Charles Ewert)](https://github.com/cewert)
-    - Fix code formatting ([PR #805](https://github.com/RokuCommunity/brighterscript/pull/805))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Update README.md ([PR #804](https://github.com/RokuCommunity/brighterscript/pull/804))
-    - Improve findChild and findAncestor AST methods ([PR #807](https://github.com/RokuCommunity/brighterscript/pull/807))
-    - npm audit fixes. upgrade to coveralls-next ([43756d8](https://github.com/RokuCommunity/brighterscript/commit/43756d8))
+
+-   [@cewert (Charles Ewert)](https://github.com/cewert)
+    -   Fix code formatting ([PR #805](https://github.com/RokuCommunity/brighterscript/pull/805))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Update README.md ([PR #804](https://github.com/RokuCommunity/brighterscript/pull/804))
+    -   Improve findChild and findAncestor AST methods ([PR #807](https://github.com/RokuCommunity/brighterscript/pull/807))
+    -   npm audit fixes. upgrade to coveralls-next ([43756d8](https://github.com/RokuCommunity/brighterscript/commit/43756d8))
 
 Contributions to [roku-deploy](https://github.com/RokuCommunity/roku-deploy):
- - [@fumer-fubotv (fumer-fubotv)](https://github.com/fumer-fubotv)
-    - TBD-67: roku-deploy: fix nodejs 19 bug ([PR #115](https://github.com/RokuCommunity/roku-deploy/pull/115))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix broken device tests ([fefe375](https://github.com/RokuCommunity/roku-deploy/commit/fefe375))
-    - Fix bug that overwrites signing pkg during tests ([PR #114](https://github.com/RokuCommunity/roku-deploy/pull/114))
-    - Fix audit issues ([PR #116](https://github.com/RokuCommunity/roku-deploy/pull/116))
+
+-   [@fumer-fubotv (fumer-fubotv)](https://github.com/fumer-fubotv)
+    -   TBD-67: roku-deploy: fix nodejs 19 bug ([PR #115](https://github.com/RokuCommunity/roku-deploy/pull/115))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix broken device tests ([fefe375](https://github.com/RokuCommunity/roku-deploy/commit/fefe375))
+    -   Fix bug that overwrites signing pkg during tests ([PR #114](https://github.com/RokuCommunity/roku-deploy/pull/114))
+    -   Fix audit issues ([PR #116](https://github.com/RokuCommunity/roku-deploy/pull/116))
 
 Contributions to [logger](https://github.com/RokuCommunity/logger):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix build status badge ([b1e490b](https://github.com/RokuCommunity/logger/commit/b1e490b))
-    - Fix workflow build link ([b851603](https://github.com/RokuCommunity/logger/commit/b851603))
-    - Fix dependencies ([04af7a0](https://github.com/RokuCommunity/logger/commit/04af7a0))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix build status badge ([b1e490b](https://github.com/RokuCommunity/logger/commit/b1e490b))
+    -   Fix workflow build link ([b851603](https://github.com/RokuCommunity/logger/commit/b851603))
+    -   Fix dependencies ([04af7a0](https://github.com/RokuCommunity/logger/commit/04af7a0))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Fix crash by using postman-request ([PR #151](https://github.com/RokuCommunity/roku-debug/pull/151))
-    - Fix `file already exists` error and hung process ([PR #152](https://github.com/RokuCommunity/roku-debug/pull/152))
-    - Remove axios in favor of postman-request ([PR #153](https://github.com/RokuCommunity/roku-debug/pull/153))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix crash by using postman-request ([PR #151](https://github.com/RokuCommunity/roku-debug/pull/151))
+    -   Fix `file already exists` error and hung process ([PR #152](https://github.com/RokuCommunity/roku-debug/pull/152))
+    -   Remove axios in favor of postman-request ([PR #153](https://github.com/RokuCommunity/roku-debug/pull/153))

--- a/src/pages/whats-new/2023-06-June.md
+++ b/src/pages/whats-new/2023-06-June.md
@@ -3,21 +3,25 @@ date: June 2023
 summary: BrighterScript type checking alpha released, BrighterScript class super() bugfix, vscode debug fileLogging
 layout: ../../layouts/WhatsNewPost.astro
 ---
+
 # Overview
+
 June was a fairly slow month in terms of new releases, as many of us were on vacation or busy with behind-the-scenes features. However, we did fix a few bugs in BrighterScript, and we have an exciting announcement to make about [type validation support in BrighterScript](#brighterscript-type-validation-released-in-alpha)!
 
 ## We need your help
 
 The RokuCommunity projects are maintained by a relatively small group of developers (mostly volunteers), and we have a growing list of of unresolved issues. We need your help! There are many different ways you can contribute. Whether it's addressing bugs, improving documentation, introducing new features, or simply helping us manage our expanding list of GitHub issues, your involvement would be greatly appreciated. We are more than happy to guide you in finding the most suitable contribution method that aligns with your interests. To learn more about how you can contribute, feel free to reach out to us on [Slack](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA), or explore the existing GitHub issues:
-- [vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language/issues)
-- [brighterscript](https://github.com/rokucommunity/brighterscript/issues)
-- [brighterscript-formatter](https://github.com/rokucommunity/brighterscript-formatter/issues)
-- [roku-deploy](https://github.com/rokucommunity/roku-deploy/issues)
-- [roku-debug](https://github.com/rokucommunity/roku-debug/issues)
-- [bslint](https://github.com/rokucommunity/bslint/issues)
-- [ropm](https://github.com/rokucommunity/ropm/issues)
+
+-   [vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language/issues)
+-   [brighterscript](https://github.com/rokucommunity/brighterscript/issues)
+-   [brighterscript-formatter](https://github.com/rokucommunity/brighterscript-formatter/issues)
+-   [roku-deploy](https://github.com/rokucommunity/roku-deploy/issues)
+-   [roku-debug](https://github.com/rokucommunity/roku-debug/issues)
+-   [bslint](https://github.com/rokucommunity/bslint/issues)
+-   [ropm](https://github.com/rokucommunity/ropm/issues)
 
 ## Issue of the month
+
 In this section, we highlight a specific issue where we could benefit from the community's assistance in finding a solution. These problems are generally straightforward to address, and serve as an excellent opportunity to become acquainted with the RokuCommunity codebases.
 
 This month, we'd like to draw attention to [vscode-brightscript-language#475: Add launch setting to manage Remote Control Mode](https://github.com/rokucommunity/vscode-brightscript-language/issues/475).
@@ -29,7 +33,6 @@ The VSCode extension has a neat feature called "Remote Control Mode" that conver
 [vscode-brightscript-language#475](https://github.com/rokucommunity/vscode-brightscript-language/issues/475) will take that one step further by adding a new launch.json option to automatically enable Remote Control Mode when you start a debug session, and disable Remote Control Mode when you stop a debug session.
 
 If you're interested in working on this feature, please comment on the [pull request](https://github.com/rokucommunity/vscode-brightscript-language/issues/475) or reach out to us on [Slack](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA)
-
 
 # Debugging
 
@@ -48,28 +51,30 @@ We've fixed a bug in the BrighterScript transpiler so that it no longer injects 
 ![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/108a540b-d9a3-4e7c-ac73-19e47d933871)
 
 ## BrighterScript Type Validation released in alpha!
+
 We've been hard at work adding a type system to BrighterScript, and we're super excited to announce alpha builds of these upcoming changes. All of the type tracking/validation will be included in the upcoming `v0.66.0` release, so we've started publishing alpha builds. v0.66.0.alpha-2 is the latest build in June (but there may be newer releases if you're reading this from the future!). Shout out to [@markwpearce (Mark Pearce)](https://github.com/markwpearce) for all of the hard work on this effort.
 
 The work done here in June has mostly been under-the-hood changes to prepare for much more advanced type validation logic. Keep an eye out for July's what's new writeup, as we will hopefully have much more practical and exciting type validations to show off then!
 
-
-
 **NOTE:** v0.66.0 will include many _breaking_ changes for brighterscript plugins. See [this section](#plugin-authors) for more details.
 
 We will be creating a much more in-depth writeup of all the new features and changes once v0.66.0 is released out of alpha, but here are some highlights of the progress made this month:
- - better Better namespace "can't find this property" range
-    ![image](https://user-images.githubusercontent.com/2544493/244416204-8d7d046a-56c0-4da4-8cea-9dbb89559431.png)
- - adds ability to typecast expressions to help the type system better understand your variables. ([#814](https://github.com/rokucommunity/brighterscript/pull/814))
-     Allows code like:
-     ```vb
-     sub main()
-         value = (getValue() as integer).toStr()
-     end sub
 
-     function getValue()
-         return 123
-     end function
-     ```
+-   better Better namespace "can't find this property" range
+    ![image](https://user-images.githubusercontent.com/2544493/244416204-8d7d046a-56c0-4da4-8cea-9dbb89559431.png)
+-   adds ability to typecast expressions to help the type system better understand your variables. ([#814](https://github.com/rokucommunity/brighterscript/pull/814))
+    Allows code like:
+
+    ```vb
+    sub main()
+        value = (getValue() as integer).toStr()
+    end sub
+
+    function getValue()
+        return 123
+    end function
+    ```
+
 ### Installing latest brighterscript alphas
 
 To install the latest brighterscript alphas, you can run the following command:
@@ -79,18 +84,19 @@ npm install brighterscript@next
 ```
 
 Then, if you want to use this version as a language server, set the following option in your vscode `settings.json` file and restart vscode:
+
 ```json
 "brighterscript.bsdk": "./node_modules/brighterscript"
 ```
 
 ### Breaking changes
+
 The BrighterScript v0.66.0 alphas have also made a few changes to the underlying BrighterScript APIs. We wanted to call most of the high level changes so you know what to look for as you update your plugins to support the upcoming v0.66.0 release
 
-
-- Add a new AstNode class called `TypeExpression`, which is the base AstNode for all future type expressions ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
-- Add a getType() method to the base `AstNode`, which can then be overridden by all AstNode descendents.
-- enhance `SymbolTable` to actually include the variable types ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
-- Validate all TypeExpression AstNodes to ensure they reference valid types that can be found in the symbol table ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
+-   Add a new AstNode class called `TypeExpression`, which is the base AstNode for all future type expressions ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
+-   Add a getType() method to the base `AstNode`, which can then be overridden by all AstNode descendents.
+-   enhance `SymbolTable` to actually include the variable types ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
+-   Validate all TypeExpression AstNodes to ensure they reference valid types that can be found in the symbol table ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
 
 Here are some additional more detailed changes:
 
@@ -156,26 +162,28 @@ afterProgramCreate(event: AfterProgramCreateEvent) {
 ```
 
 # Thank you
-Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
- - [@josephjunker (Joseph Junker)](https://github.com/josephjunker)
-    - Fix injection of duplicate super calls into classes ([PR #823](https://github.com/RokuCommunity/brighterscript/pull/823))
- - [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    - Fixes issue with Namespace Declaration order ([PR #822](https://github.com/RokuCommunity/brighterscript/pull/822))
-    - Fixes issue with multiple namespace symbol tables ([PR #825](https://github.com/RokuCommunity/brighterscript/pull/825))
-    - Fixes some issues related to Classes as Properties and Consts validation ([PR #826](https://github.com/RokuCommunity/brighterscript/pull/826))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Add warning to top of readme ([c943bf2](https://github.com/RokuCommunity/brighterscript/commit/c943bf2))
-    - Type Tracking ([PR #783](https://github.com/RokuCommunity/brighterscript/pull/783))
-    - Adds .kind prop to AstNode. ([PR #799](https://github.com/RokuCommunity/brighterscript/pull/799))
-    - Xml ast refactor ([PR #818](https://github.com/RokuCommunity/brighterscript/pull/818))
-    - Rename SymbolTypeFlags to SymbolTypeFlag ([PR #819](https://github.com/RokuCommunity/brighterscript/pull/819))
-    - Remove deprecated stuff ([PR #820](https://github.com/RokuCommunity/brighterscript/pull/820))
-    - Better prop diagnostic range. add ProgramBuilder.load func ([PR #821](https://github.com/RokuCommunity/brighterscript/pull/821))
-    - Convert plugin params to single event object ([PR #824](https://github.com/RokuCommunity/brighterscript/pull/824))
+
+-   [@josephjunker (Joseph Junker)](https://github.com/josephjunker)
+    -   Fix injection of duplicate super calls into classes ([PR #823](https://github.com/RokuCommunity/brighterscript/pull/823))
+-   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
+    -   Fixes issue with Namespace Declaration order ([PR #822](https://github.com/RokuCommunity/brighterscript/pull/822))
+    -   Fixes issue with multiple namespace symbol tables ([PR #825](https://github.com/RokuCommunity/brighterscript/pull/825))
+    -   Fixes some issues related to Classes as Properties and Consts validation ([PR #826](https://github.com/RokuCommunity/brighterscript/pull/826))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Type Tracking ([PR #783](https://github.com/RokuCommunity/brighterscript/pull/783))
+    -   Adds .kind prop to AstNode. ([PR #799](https://github.com/RokuCommunity/brighterscript/pull/799))
+    -   Xml ast refactor ([PR #818](https://github.com/RokuCommunity/brighterscript/pull/818))
+    -   Rename SymbolTypeFlags to SymbolTypeFlag ([PR #819](https://github.com/RokuCommunity/brighterscript/pull/819))
+    -   Remove deprecated stuff ([PR #820](https://github.com/RokuCommunity/brighterscript/pull/820))
+    -   Better prop diagnostic range. add ProgramBuilder.load func ([PR #821](https://github.com/RokuCommunity/brighterscript/pull/821))
+    -   Convert plugin params to single event object ([PR #824](https://github.com/RokuCommunity/brighterscript/pull/824))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - File logging ([PR #155](https://github.com/RokuCommunity/roku-debug/pull/155))
-    - Move @types/request to deps to fix d.bs files ([691a7be](https://github.com/RokuCommunity/roku-debug/commit/691a7be))
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   File logging ([PR #155](https://github.com/RokuCommunity/roku-debug/pull/155))
+    -   Move @types/request to deps to fix d.bs files ([691a7be](https://github.com/RokuCommunity/roku-debug/commit/691a7be))

--- a/src/pages/whats-new/2023-06-June.md
+++ b/src/pages/whats-new/2023-06-June.md
@@ -4,7 +4,7 @@ summary: BrighterScript type checking alpha released, BrighterScript class super
 layout: ../../layouts/WhatsNewPost.astro
 ---
 # Overview
-June was a fairly slow month in terms of new releases, as many of us were on vacation or busy with behind-the-scenes features. However, we did fix a few bugs in BrighterScript, and we have an exciting announcement to make about [type validation support in BrighterScript](#brighterscript-type-validation-released-in-alpha)! 
+June was a fairly slow month in terms of new releases, as many of us were on vacation or busy with behind-the-scenes features. However, we did fix a few bugs in BrighterScript, and we have an exciting announcement to make about [type validation support in BrighterScript](#brighterscript-type-validation-released-in-alpha)!
 
 ## We need your help
 
@@ -20,13 +20,13 @@ The RokuCommunity projects are maintained by a relatively small group of develop
 ## Issue of the month
 In this section, we highlight a specific issue where we could benefit from the community's assistance in finding a solution. These problems are generally straightforward to address, and serve as an excellent opportunity to become acquainted with the RokuCommunity codebases.
 
-This month, we'd like to draw attention to [vscode-brightscript-language#475: Add launch setting to manage Remote Control Mode](https://github.com/rokucommunity/vscode-brightscript-language/issues/475). 
+This month, we'd like to draw attention to [vscode-brightscript-language#475: Add launch setting to manage Remote Control Mode](https://github.com/rokucommunity/vscode-brightscript-language/issues/475).
 
 The VSCode extension has a neat feature called "Remote Control Mode" that converts your entire keyboard into a roku remote. You can even type alphanumeric characters into text boxes on the Roku with this enabled. Remote Control Mode is activated by clicking the toggle button in the statusbar.
 
 ![remote-control-mode](https://github.com/rokucommunity/rokucommunity.github.io/assets/2544493/b2e0bb7f-668f-4255-bcd0-b0bc92ea1d92)
 
-[vscode-brightscript-language#475](https://github.com/rokucommunity/vscode-brightscript-language/issues/475) will take that one step further by adding a new launch.json option to automatically enable Remote Control Mode when you start a debug session, and disable Remote Control Mode when you stop a debug session. 
+[vscode-brightscript-language#475](https://github.com/rokucommunity/vscode-brightscript-language/issues/475) will take that one step further by adding a new launch.json option to automatically enable Remote Control Mode when you start a debug session, and disable Remote Control Mode when you stop a debug session.
 
 If you're interested in working on this feature, please comment on the [pull request](https://github.com/rokucommunity/vscode-brightscript-language/issues/475) or reach out to us on [Slack](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA)
 
@@ -35,7 +35,7 @@ If you're interested in working on this feature, please comment on the [pull req
 
 ## File logging
 
-We've added a new `fileLogging` launch option for debug sessions in the VSCode extension. Roku developers can enable this flag and then submit the debug logs with their github issues, which will greatly improve our ability to reproduce and fix bugs in the debugger. 
+We've added a new `fileLogging` launch option for debug sessions in the VSCode extension. Roku developers can enable this flag and then submit the debug logs with their github issues, which will greatly improve our ability to reproduce and fix bugs in the debugger.
 
 ![filelogging](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/10d28ba8-ea1a-4a44-80cb-050b44402abe)
 
@@ -54,18 +54,18 @@ The work done here in June has mostly been under-the-hood changes to prepare for
 
 
 
-**NOTE:** v0.66.0 will include many _breaking_ changes for brighterscript plugins. See [this section](#plugin-authors) for more details. 
+**NOTE:** v0.66.0 will include many _breaking_ changes for brighterscript plugins. See [this section](#plugin-authors) for more details.
 
 We will be creating a much more in-depth writeup of all the new features and changes once v0.66.0 is released out of alpha, but here are some highlights of the progress made this month:
  - better Better namespace "can't find this property" range
     ![image](https://user-images.githubusercontent.com/2544493/244416204-8d7d046a-56c0-4da4-8cea-9dbb89559431.png)
- - adds ability to typecast expressions to help the type system better understand your variables. ([#814](https://github.com/rokucommunity/brighterscript/pull/814))   
+ - adds ability to typecast expressions to help the type system better understand your variables. ([#814](https://github.com/rokucommunity/brighterscript/pull/814))
      Allows code like:
      ```vb
      sub main()
          value = (getValue() as integer).toStr()
      end sub
- 
+
      function getValue()
          return 123
      end function
@@ -83,44 +83,99 @@ Then, if you want to use this version as a language server, set the following op
 "brighterscript.bsdk": "./node_modules/brighterscript"
 ```
 
-### Plugin authors
-The BrighterScript v0.66.0 alphas have also made a few changes to the underlying BrighterScript APIs. We won't get too detailed here, but we wanted to call out the high level changes so you know what to look for as you update your plugins to support the upcoming v0.66.0 release
-- We've refactored the XML ast structure to be more intuitive. This is mostly a behind-the-scenes change, but plugin authors will need update any of their XML ast logic ([#799](https://github.com/RokuCommunity/brighterscript/pull/799))
-- Converts all plugin event parameters to be a single event object rather than ordered parameters. ([#824](https://github.com/RokuCommunity/brighterscript/pull/824))
-- added a `.kind` property to AstNode, and an `AstNodeKind` enum. ([#799](https://github.com/RokuCommunity/brighterscript/pull/799)) This converts the reflection methods to check for `.kind` instead of the `thing?.constructor?.name === 'Whatever'` logic which was quite slow. Raw benchmarks show a 10-12 percent performance boost during validation: 
+### Breaking changes
+The BrighterScript v0.66.0 alphas have also made a few changes to the underlying BrighterScript APIs. We wanted to call most of the high level changes so you know what to look for as you update your plugins to support the upcoming v0.66.0 release
 
-    ![image](https://user-images.githubusercontent.com/2544493/234746091-cacae55f-a825-4007-91da-23b26a4e0c7f.png)
+
 - Add a new AstNode class called `TypeExpression`, which is the base AstNode for all future type expressions ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
 - Add a getType() method to the base `AstNode`, which can then be overridden by all AstNode descendents.
 - enhance `SymbolTable` to actually include the variable types ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
 - Validate all TypeExpression AstNodes to ensure they reference valid types that can be found in the symbol table ([#783](https://github.com/RokuCommunity/brighterscript/pull/783))
-- removed deprecated items from the code ([#820](https://github.com/RokuCommunity/brighterscript/pull/820))
 
+Here are some additional more detailed changes:
+
+## add `.kind` prop to `AstNode`
+
+AST Nodes in the BrighterScript parse tree have historically been identified by looking at their class name, like this: `node?.constructor?.name === 'IfStatement'`. This is not the fastest operation because we have _two_ optional chaining expressions, as well as digging into the underlying NodeJS class naming logic.
+
+To mitigate this, and also make AstNode reflection more straightforward, we've now added a `.kind` property to all AstNode instances. This results in about a 10-12% speed improvement during validation. All of the included AST reflection methods like `isIfStatement` and `isCallExpression` have been updated to leverage this new property, and will no longer check based on the class name.
+
+This is a breaking change, as all plugins that produce AST would need to be upgraded to the latest version of brighterscript in order to work with the version of brighterscript shipped with the vscode extension. For example, latest version of brighterscript being used with a plugin that depends on an older version of brighterscript. However, like we've previously mentioned, there are enough other breaking changes in this release that you'll already be required to upgrade anyway.
+
+Raw benchmarks show this as a fairly significant boost:
+
+![image](https://user-images.githubusercontent.com/2544493/234745941-ecf12cfd-cb6b-4755-8497-ac03817fb38c.png)
+
+What that means in practice is validation speeds improve by 10-12 percent.
+
+![image](https://user-images.githubusercontent.com/2544493/234746091-cacae55f-a825-4007-91da-23b26a4e0c7f.png)
+
+## XML AST Refactor
+
+In the mainline brighterscript release, there were several situations where plugins couldn't modify XML during transpilation due to the way the XML AST was structured. We've now refactored that to make the XML AST much more flexible. All transpiling is driven directly by the AST, and any helper methods or arrays have been converted into getters in order to improve interaction with the AST. There's no noticeable performance hit for most things, but you can actually see a large boost in transpile performance for XML files!
+
+![image](https://user-images.githubusercontent.com/2544493/243781262-ae0f3326-5913-4365-9848-dedd578b7434.png)
+
+### Removed deprecated items
+
+we have removed deprecated items from the code base including
+
+-   retainStagingFolder
+-   stagingFolderPath
+-   pathAbsolute
+-   fileContents
+-   fileEntry
+-   createClassMethodStatement
+-   ClassFieldStatement
+-   ClassMethodStatement
+-   isClassFieldStatement
+-   namespaceName()
+-   parentFunction()
+-   childFunctionExpresssions()
+    [#820](https://github.com/RokuCommunity/brighterscript/pull/820)
+
+### Single event object replaces ordered parameters for plugin events
+
+When the brighterscript plugin system first launched, the event callbacks all required ordered parameters. However, this quickly became difficult to expand upon, as we often wanted to add additional params that didn't make sense at the end of the list but we couldn't change their order. So a year or so ago we started requiring that all _new_ event callbacks must use the object pattern instead.
+
+Since we're already introducing several other breaking changes in the alphas, we figured this would be a great time to also migrate all plugins to the object pattern. This _does_ mean that your < v0.66 plugin events will no longer work in v0.66 or above, but since we've already introduced several other breaking changes (listed above), this shouldn't be too much more of a lift.
+
+You can review [brighterscript#824](https://github.com/RokuCommunity/brighterscript/pull/824) to get an idea for the new structure of the plugin events. Here's a small example:
+
+```typescript
+//old pattern
+afterProgramCreate(program: Program) {
+    //do stuff
+}
+
+//new pattern
+afterProgramCreate(event: AfterProgramCreateEvent) {
+    const program = event.program;
+    //do stuff
+}
+```
 
 # Thank you
-
 Last but certainly not least, a big ***Thank You*** to the following people who contributed this month:
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
  - [@josephjunker (Joseph Junker)](https://github.com/josephjunker)
     - Fix injection of duplicate super calls into classes ([PR #823](https://github.com/RokuCommunity/brighterscript/pull/823))
- - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    - Merge branch 'master' of https://github.com/rokucommunity/brighterscript into release-0.66.0 ([f6343a6](https://github.com/RokuCommunity/brighterscript/commit/f6343a6))
-    - Better prop diagnostic range. add ProgramBuilder.load func ([PR #821](https://github.com/RokuCommunity/brighterscript/pull/821))
-    - Remove deprecated stuff ([PR #820](https://github.com/RokuCommunity/brighterscript/pull/820))
-    - Rename SymbolTypeFlags to SymbolTypeFlag ([PR #819](https://github.com/RokuCommunity/brighterscript/pull/819))
-    - Xml ast refactor ([PR #818](https://github.com/RokuCommunity/brighterscript/pull/818))
-    - Adds .kind prop to AstNode. ([PR #799](https://github.com/RokuCommunity/brighterscript/pull/799))
-    - Type Tracking ([PR #783](https://github.com/RokuCommunity/brighterscript/pull/783))
-    - Add warning to top of readme ([c943bf2](https://github.com/RokuCommunity/brighterscript/commit/c943bf2))
-    - Convert plugin params to single event object ([PR #824](https://github.com/RokuCommunity/brighterscript/pull/824))
  - [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
     - Fixes issue with Namespace Declaration order ([PR #822](https://github.com/RokuCommunity/brighterscript/pull/822))
     - Fixes issue with multiple namespace symbol tables ([PR #825](https://github.com/RokuCommunity/brighterscript/pull/825))
     - Fixes some issues related to Classes as Properties and Consts validation ([PR #826](https://github.com/RokuCommunity/brighterscript/pull/826))
+ - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    - Add warning to top of readme ([c943bf2](https://github.com/RokuCommunity/brighterscript/commit/c943bf2))
+    - Type Tracking ([PR #783](https://github.com/RokuCommunity/brighterscript/pull/783))
+    - Adds .kind prop to AstNode. ([PR #799](https://github.com/RokuCommunity/brighterscript/pull/799))
+    - Xml ast refactor ([PR #818](https://github.com/RokuCommunity/brighterscript/pull/818))
+    - Rename SymbolTypeFlags to SymbolTypeFlag ([PR #819](https://github.com/RokuCommunity/brighterscript/pull/819))
+    - Remove deprecated stuff ([PR #820](https://github.com/RokuCommunity/brighterscript/pull/820))
+    - Better prop diagnostic range. add ProgramBuilder.load func ([PR #821](https://github.com/RokuCommunity/brighterscript/pull/821))
+    - Convert plugin params to single event object ([PR #824](https://github.com/RokuCommunity/brighterscript/pull/824))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
  - [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     - File logging ([PR #155](https://github.com/RokuCommunity/roku-debug/pull/155))
     - Move @types/request to deps to fix d.bs files ([691a7be](https://github.com/RokuCommunity/roku-debug/commit/691a7be))
-    

--- a/src/pages/whats-new/2023-07-July.md
+++ b/src/pages/whats-new/2023-07-July.md
@@ -277,7 +277,7 @@ BrighterScript interfaces were introduced back in [June 2021](https://github.com
 
 # Thank you
 
-Last but certainly not least, a big _**Thank You**_ to the following people who contributed this month:
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
 

--- a/src/pages/whats-new/2023-07-July.md
+++ b/src/pages/whats-new/2023-07-July.md
@@ -5,6 +5,7 @@ layout: ../../layouts/WhatsNewPost.astro
 ---
 
 # Overview
+
 Whew! It's been a busy month. We've added a busy spinner in vscode for you to know when the language server is doing work, added ECP rendezvous tracking, and bunch more! We (mostly [Mark Pearce](https://github.com/markwpearce)) also made some serious progress on the BrighterScript type tracking features in the latest v0.66 alphas.
 
 ## We need your help
@@ -130,7 +131,7 @@ If you're a regular user of bslint, you may have experienced a bug where variabl
 
 ### 20% performance improvement by caching global scope identifiers
 
-We found some significant performance improvements (up to 20% faster) by fixing a bug in the varTracking logic that was re-calculating the scope globals too frequently (for each file for each scope). Since the scope globals are shared across every file in that scope, we can lift that calculation so that it's only run once per scope.
+We found some significant performance improvements (up to 20% faster) in by fixing a bug in the varTracking logic that was re-calculating the scope globals too frequently (for each file for each scope). Since the scope globals are shared across every file in that scope, we can lift that calculation so that it's only run once per scope. ([bslint#92](https://github.com/RokuCommunity/bslint/pull/92))
 
 This shaved off 1,300ms from the validation cycle of a large internal project
 
@@ -207,14 +208,17 @@ We've added much better validations around when functions are used as parameters
 ![image](https://github.com/rokucommunity/rokucommunity.github.io/assets/2544493/fce7cf89-e2be-44ea-9146-87cd0675a6fa)
 
 ### allow `as Object` passing in the manner of `as Dynamic`
+
 We fixed some bugs in the type tracking related to `as object`. `Object` types can now properly be passed to any function type, just like dynamic. (see [#850](https://github.com/RokuCommunity/brighterscript/pull/850) for more info)
 
 ### pass `enums` as literal values
+
 We no longer show a warning when passing enum values to functions expecting a compatible primitive type.
 
 ![image](https://github.com/rokucommunity/rokucommunity.github.io/assets/2544493/498d981d-a7a8-40ce-950b-50ba6010d2a1)
 
 ## `0.66.0` performance fixes
+
 As we added new type tracking validations to BrighterScript, we noticed that performance was starting to slow down significantly. So we spent some time optimizing the internal logic in brighterscript to regain some of the lost performance. You can check out [brighterscript#834](https://github.com/RokuCommunity/brighterscript/pull/834) for the specific changes, but here's an overview:
 
 Overall improvement (to a large proprietary project):
@@ -241,83 +245,29 @@ optimize `util.getAllDottedGetPartsAsString`
 
     ![image](https://user-images.githubusercontent.com/2544493/252391322-7277f022-7d58-478d-b89b-dc71dd8736fa.png)
 
-- optimize `cache.getOrAdd` to call `super.has()` and `super.get()` instead of `this.\*` which eliminates some prototype lookups.
+-   optimize `cache.getOrAdd` to call `super.has()` and `super.get()` instead of `this.\*` which eliminates some prototype lookups.
 
 ![image](https://user-images.githubusercontent.com/2544493/252745475-c908ace1-4e62-4e32-b1ca-04a27ec702ce.png)
 
-- optimize `scope.buildNamespaceLookup()`
+-   optimize `scope.buildNamespaceLookup()`
 
 ![image](https://user-images.githubusercontent.com/2544493/253628589-b5cb9a1a-62fb-4460-be63-b1f8ef5e3adc.png)
 
-
-
-
 ### Eliminate `enableTypeValidation` flag
+
 In the first few releases of v0.66.0-alpha, we had added a `enableTypeValidation` flag to help with performance issues. however, with the performance fixes mentioned above, there wasn't much value in having the logic be separate (and it would complicate future work anyway), so we have now removed `enableTypeValidation` as of v0.66.0-alpha.3.
 
 ### Other miscelaneous type tracking changes
 
--   fixes a type resolve issue when a class is already a property of another class ([#826](https://github.com/RokuCommunity/brighterscript/pull/826))
 -   `const` values now can be composed of other `const` values ([#826](https://github.com/RokuCommunity/brighterscript/pull/826))
 -   does a better job of caching symbol lookups on memberTables ([#826](https://github.com/RokuCommunity/brighterscript/pull/826))
--   now creates a single `namespacetype` per namespace scope and adds further symbol tables as sibling tables below that namespace ([#825](https://github.com/RokuCommunity/brighterscript/pull/825))
--   now permits namespaces to be declared in any order ([#822](https://github.com/RokuCommunity/brighterscript/pull/822))
 -   add `load` method to `ProgramBuilder` for testing to decouple loading from running, mostly for testing, decouple loading from running by adding the `load` method to `ProgramBuilder` ([#821](https://github.com/RokuCommunity/brighterscript/pull/821))
--   renamed `SymbolTypeFlags` to `SymbolTypeFlag` ([#819](https://github.com/RokuCommunity/brighterscript/pull/819))
-- assignment from return of member functions of primitive types ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
-- using invalid as a default param value (now sets type to dynamic). allows any variable to passed as argument to an untyped param with default type invalid ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
-- adds Roku_Event_Dispatcher() global callable (from library Roku_Event_Dispatcher.brs) ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
-- Fixes [FormatJson()]((https://developer.roku.com/docs/references/brightscript/language/global-utility-functions.md#formatjsonjson-as-object-flags--0-as-integer-as-string)) function signature  ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
+-   assignment from return of member functions of primitive types ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
+-   using invalid as a default param value (now sets type to dynamic). allows any variable to passed as argument to an untyped param with default type invalid ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
+-   adds Roku_Event_Dispatcher() global callable (from library Roku_Event_Dispatcher.brs) ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
+-   Fixes [FormatJson()](<(https://developer.roku.com/docs/references/brightscript/language/global-utility-functions.md#formatjsonjson-as-object-flags--0-as-integer-as-string)>) function signature ([#855](https://github.com/RokuCommunity/brighterscript/pull/855))
 
 ## Breaking Changes
-### Removed deprecated items
-
-we have removed deprecated items from the code base including
-
--   retainStagingFolder
--   stagingFolderPath
--   pathAbsolute
--   fileContents
--   fileEntry
--   createClassMethodStatement
--   ClassFieldStatement
--   ClassMethodStatement
--   isClassFieldStatement
--   namespaceName()
--   parentFunction()
--   childFunctionExpresssions()
-    [#820](https://github.com/RokuCommunity/brighterscript/pull/820)
-
-
-## Single event object replaces ordered parameters for plugin events
-
-When the brighterscript plugin system first launched, the event callbacks all required ordered parameters. However, this quickly became difficult to expand upon, as we often wanted to add additional params that didn't make sense at the end of the list but we couldn't change their order. So a year or so ago we started requiring that all _new_ event callbacks must use the object pattern instead. Since we're already introducing several other breaking changes in the alphas, we figured this would be a great time to also migrate all plugins to the object pattern. This _does_ mean that your < v0.66 plugin events will no longer work in v0.66 or above, but since we've already introduced several other breaking changes in [last month's writeup](https://rokucommunity.github.io/whats-new/2023-06-June/#plugin-authors), this shouldn't be too much more of a lift.
-
-You can review [brighterscript#824](https://github.com/RokuCommunity/brighterscript/pull/824) to get an idea for the new structure of the plugin events.
-
-## AstNode.kind
-
-## add `.kind` prop to `AstNode`
-
-AST Nodes in the BrighterScript parse tree have historically been identified by looking at their class name, like this: `node?.constructor?.name === 'IfStatement'`. This is not the fastest operation because we have _two_ optional chaining expressions, as well as digging into the underlying NodeJS class naming logic.
-
-To mitigate this, and also make AstNode reflection more straightforward, we've now added a `.kind` property to all AstNode instances. This results in about a 10-12% speed improvement during validation. All of the included AST reflection methods like `isIfStatement` and `isCallExpression` have been updated to leverage this new property, and will no longer check based on the class name.
-
-This is a breaking change, as all plugins that produce AST would need to be upgraded to the latest version of brighterscript in order to work with the version of brighterscript shipped with the vscode extension. For example, latest version of brighterscript being used with a plugin that depends on an older version of brighterscript. However, like we've previously mentioned, there are enough other breaking changes in this release that you'll already be required to upgrade anyway.
-
-Raw benchmarks show this as a fairly significant boost:
-
-![image](https://user-images.githubusercontent.com/2544493/234745941-ecf12cfd-cb6b-4755-8497-ac03817fb38c.png)
-
-What that means in practice is validation speeds improve by 10-12 percent.
-
-![image](https://user-images.githubusercontent.com/2544493/234746091-cacae55f-a825-4007-91da-23b26a4e0c7f.png)
-
-## XML AST Refactor
-
-In the mainline brighterscript release, there were several situations where plugins couldn't modify XML during transpilation due to the way the XML AST was structured. We've now refactored that to make the XML AST much more flexible. All transpiling is driven directly by the AST, and any helper methods or arrays have been converted into getters in order to improve interaction with the AST. There's no noticeable performance hit for most things, but you can actually see a large boost in transpile performance for XML files!
-
-![image](https://user-images.githubusercontent.com/2544493/243781262-ae0f3326-5913-4365-9848-dedd578b7434.png)
 
 # Documentation
 
@@ -327,53 +277,42 @@ BrighterScript interfaces were introduced back in [June 2021](https://github.com
 
 # Thank you
 
-Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
+Last but certainly not least, a big _**Thank You**_ to the following people who contributed this month:
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
 
 -   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    -   Rendezvous tracking ([PR #490](https://github.com/RokuCommunity/vscode-brightscript-language/pull/490))
-    -   Fix iface syntax highlighting for comments & funcs ([PR #489](https://github.com/RokuCommunity/vscode-brightscript-language/pull/489))
-    -   fix a few npm audit issues ([4121aee](https://github.com/RokuCommunity/vscode-brightscript-language/commit/4121aee))
     -   Add fileLogging launch.json option ([PR #487](https://github.com/RokuCommunity/vscode-brightscript-language/pull/487))
+    -   fix a few npm audit issues ([4121aee](https://github.com/RokuCommunity/vscode-brightscript-language/commit/4121aee))
+    -   Fix iface syntax highlighting for comments & funcs ([PR #489](https://github.com/RokuCommunity/vscode-brightscript-language/pull/489))
+    -   Rendezvous tracking ([PR #490](https://github.com/RokuCommunity/vscode-brightscript-language/pull/490))
     -   Show a spinner in the statusbar when lsp is busy ([PR #492](https://github.com/RokuCommunity/vscode-brightscript-language/pull/492))
     -   Add deleteDevChannelBeforeInstall launch option ([PR #494](https://github.com/RokuCommunity/vscode-brightscript-language/pull/494))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
 
 -   [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
-    -   Expose event interface ([PR #845](https://github.com/RokuCommunity/brighterscript/pull/845))
-    -   Add beforeProgramDispose event ([PR #844](https://github.com/RokuCommunity/brighterscript/pull/844))
     -   Make component ready on afterScopeCreate ([PR #843](https://github.com/RokuCommunity/brighterscript/pull/843))
+    -   Add beforeProgramDispose event ([PR #844](https://github.com/RokuCommunity/brighterscript/pull/844))
+    -   Expose event interface ([PR #845](https://github.com/RokuCommunity/brighterscript/pull/845))
+-   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
+    -   Remove enable type validation option ([PR #846](https://github.com/RokuCommunity/brighterscript/pull/846))
+    -   Phase 2 of Typing Improvements ([PR #827](https://github.com/RokuCommunity/brighterscript/pull/827))
+    -   Functions as params ([PR #853](https://github.com/RokuCommunity/brighterscript/pull/853))
+    -   Bunch of small fixes ([PR #855](https://github.com/RokuCommunity/brighterscript/pull/855))
 -   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    -   Add project index to language server log entries ([PR #836](https://github.com/RokuCommunity/brighterscript/pull/836))
-    -   Convert all benchmarks to typescript. ([PR #835](https://github.com/RokuCommunity/brighterscript/pull/835))
-    -   Add profiling support to the cli ([PR #833](https://github.com/RokuCommunity/brighterscript/pull/833))
-    -   Prevent crashing when diagnostic is missing range. ([PR #832](https://github.com/RokuCommunity/brighterscript/pull/832))
-    -   Prevent crash when diagnostic is missing range ([PR #831](https://github.com/RokuCommunity/brighterscript/pull/831))
     -   Add baseline interface docs ([PR #829](https://github.com/RokuCommunity/brighterscript/pull/829))
-    -   Convert plugin params to single event object ([PR #824](https://github.com/RokuCommunity/brighterscript/pull/824))
-    -   Better prop diagnostic range. add ProgramBuilder.load func ([PR #821](https://github.com/RokuCommunity/brighterscript/pull/821))
-    -   Remove deprecated stuff ([PR #820](https://github.com/RokuCommunity/brighterscript/pull/820))
-    -   Rename SymbolTypeFlags to SymbolTypeFlag ([PR #819](https://github.com/RokuCommunity/brighterscript/pull/819))
-    -   Xml ast refactor ([PR #818](https://github.com/RokuCommunity/brighterscript/pull/818))
-    -   Adds .kind prop to AstNode. ([PR #799](https://github.com/RokuCommunity/brighterscript/pull/799))
-    -   Type Tracking ([PR #783](https://github.com/RokuCommunity/brighterscript/pull/783))
-    -   Add warning to top of readme ([c943bf2](https://github.com/RokuCommunity/brighterscript/commit/c943bf2))
+    -   Add missing vscode types ([c2cdf6d](https://github.com/RokuCommunity/brighterscript/commit/c2cdf6d))
+    -   Prevent crash when diagnostic is missing range ([PR #831](https://github.com/RokuCommunity/brighterscript/pull/831))
+    -   Prevent crashing when diagnostic is missing range. ([PR #832](https://github.com/RokuCommunity/brighterscript/pull/832))
+    -   Add profiling support to the cli ([PR #833](https://github.com/RokuCommunity/brighterscript/pull/833))
+    -   Convert all benchmarks to typescript. ([PR #835](https://github.com/RokuCommunity/brighterscript/pull/835))
+    -   Add project index to language server log entries ([PR #836](https://github.com/RokuCommunity/brighterscript/pull/836))
+    -   Release 0.66.0 performance fixes ([PR #834](https://github.com/RokuCommunity/brighterscript/pull/834))
+    -   Support passing enums as their literal values ([PR #849](https://github.com/RokuCommunity/brighterscript/pull/849))
+    -   Object type wider support ([PR #850](https://github.com/RokuCommunity/brighterscript/pull/850))
     -   Show busy spinner for lsp builds ([PR #852](https://github.com/RokuCommunity/brighterscript/pull/852))
     -   Install `v8-profiler-next` on demand instead of being a dependency ([PR #854](https://github.com/RokuCommunity/brighterscript/pull/854))
-    -   Object type wider support ([PR #850](https://github.com/RokuCommunity/brighterscript/pull/850))
-    -   Support passing enums as their literal values ([PR #849](https://github.com/RokuCommunity/brighterscript/pull/849))
-    -   Release 0.66.0 performance fixes ([PR #834](https://github.com/RokuCommunity/brighterscript/pull/834))
-    -   Add missing vscode types ([c2cdf6d](https://github.com/RokuCommunity/brighterscript/commit/c2cdf6d))
--   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    -   Fixes some issues related to Classes as Properties and Consts validation ([PR #826](https://github.com/RokuCommunity/brighterscript/pull/826))
-    -   Fixes issue with multiple namespace symbol tables ([PR #825](https://github.com/RokuCommunity/brighterscript/pull/825))
-    -   Fixes issue with Namespace Declaration order ([PR #822](https://github.com/RokuCommunity/brighterscript/pull/822))
-    -   Functions as params ([PR #853](https://github.com/RokuCommunity/brighterscript/pull/853))
-    -   Phase 2 of Typing Improvements ([PR #827](https://github.com/RokuCommunity/brighterscript/pull/827))
-    -   Remove enable type validation option ([PR #846](https://github.com/RokuCommunity/brighterscript/pull/846))
-    -   Bunch of small fixes ([PR #855](https://github.com/RokuCommunity/brighterscript/pull/855))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
 
@@ -385,13 +324,12 @@ Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
 
--   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    -   fix missing types ([b623648](https://github.com/RokuCommunity/bslint/commit/b623648))
-    -   Tweak build.yml to support prerelease publishing ([78f1c71](https://github.com/RokuCommunity/bslint/commit/78f1c71))
-    -   Fix code flow bug with try/catch ([PR #93](https://github.com/RokuCommunity/bslint/pull/93))
-    -   Performance boost by lifting some global lookups ([PR #92](https://github.com/RokuCommunity/bslint/pull/92))
 -   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    -   Updated peerDependency ([722b98a](https://github.com/RokuCommunity/bslint/commit/722b98a))
-    -   Updated peerDependency ([3e54289](https://github.com/RokuCommunity/bslint/commit/3e54289))
     -   Fixes for release v0.66.0-alpha1 ([cad6866](https://github.com/RokuCommunity/bslint/commit/cad6866))
-    -   Fixes for Brighterscript Typing-Phase-1 breaking changes ([53f8f9c](https://github.com/RokuCommunity/bslint/commit/53f8f9c))
+    -   Updated peerDependency ([3e54289](https://github.com/RokuCommunity/bslint/commit/3e54289))
+    -   Updated peerDependency ([722b98a](https://github.com/RokuCommunity/bslint/commit/722b98a))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Tweak build.yml to support prerelease publishing ([78f1c71](https://github.com/RokuCommunity/bslint/commit/78f1c71))
+    -   fix missing types ([b623648](https://github.com/RokuCommunity/bslint/commit/b623648))
+    -   Performance boost by lifting some global lookups ([PR #92](https://github.com/RokuCommunity/bslint/pull/92))
+    -   Fix code flow bug with try/catch ([PR #93](https://github.com/RokuCommunity/bslint/pull/93))

--- a/src/pages/whats-new/2023-08-August.md
+++ b/src/pages/whats-new/2023-08-August.md
@@ -1,0 +1,15 @@
+---
+date: August 2023
+summary: We all took a break...
+layout: ../../layouts/WhatsNewPost.astro
+---
+
+# Overview
+
+August was a very slow month for RokuCommunity. Several core community contributors had some big family changes (see [baby](https://en.wikipedia.org/wiki/Infant) and [marriage](https://en.wikipedia.org/wiki/Marriage)).
+
+Thankfully [@markwpearce](https://github.com/markwpearce) was hard at work on more BrighterScript type tracking changes! None of [these commits](https://github.com/rokucommunity/brighterscript/commits/release-0.66.0?since=2023-08-01T00:00:00Z&until=2023-08-01T23:59:59Z) were included in a release until September, but it feels kind of silly to have a "whats new" for August that doesn't at least link to some code...
+
+# Thank you
+
+We just want to take this moment to say thank you to all of our awesome users. We build all of this software because we know the immense value that it brings to your developer experience. We appreciate your support and patience as we continue to innovate and support the RokuCommunity tools.

--- a/src/pages/whats-new/2023-09-September.md
+++ b/src/pages/whats-new/2023-09-September.md
@@ -1,0 +1,445 @@
+---
+date: September 2023
+summary: Changes to vscode-brightscript-language, brighterscript, brighterscript-formatter, bslint, brs
+layout: ../../layouts/WhatsNewPost.astro
+---
+
+# Overview
+
+# brs
+
+## We adopted brs!
+
+We adopted the brs project! [brs](https://github.com/sjbarag/brs) was a BrightScript simulator that allowed for running brightscript (and some simple scenegraph) logic on Windows, Mac, and Linux. It ran on NodeJS, and was primarily developed to support the [roca](https://github.com/hulu/roca) project for off-device testing.
+
+Development on the original project stalled in September of 2021. We at RokuCommunity believe in the vision of [brs](https://github.com/sjbarag/brs), so after [some discussions with the original author](https://github.com/sjbarag/brs/issues/681), we decided to [fork](https://github.com/rokucommunity/brs) the project in order to ensure its continued development.
+
+Many thanks to [@sjbarag (Sean Barag)](https://github.com/sjbarag) for the incredible work building and guiding brs to what it is today, and to [@lvcabral (Marcelo Cabral)](https://github.com/lvcabral) for agreeing to pick up and maintain [@rokucommunity/brs](https://github.com/rokucommunity/brs) under the umbrella of RokuCommunity!
+
+# Debugging
+
+## Improvements to SceneGraph Node Inspector
+
+This month we improved the look of the node details page in SceneGraph inspector. It should feel a lot cleaner now with a proper table layout. Here's a quick demo of the new layout:
+
+![device-view](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/e8e974be-6151-4e46-bfbc-754daef17e76)
+
+Which is a nice upgrade from the old layout:
+![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/a7871d14-2113-4711-9d8b-a9f17766267d)
+
+## New Roku Test Automation panel
+
+We've added a new panel called the Roku Test Automation panel. This enables you to create a series of remote or text input commands that can be run against a Roku device. It supports running automatically on launch, or can also be run manually.
+
+Here are some highlights:
+
+-   use the record <img src="https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/e8140095-9b46-4321-87f6-b14f9863bfc6" style="display: inline"/> button to start an input recording session. you can use the built-in [remote control mode](https://rokucommunity.github.io/vscode-brightscript-language/Debugging/remote-control-mode.html) to capture a series of remote or character inputs rather than building the input sequence manually
+-   run the automation on startup or manually
+-   there's currently only support for a single sequence, but we hope to eventually add the ability to store many named sequences.
+
+In the screenshot below, you can see an automation sequence that will run wait for 8 seconds, then press `down`, `down`, `right`, `ok` on the remote in order:
+
+![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/44b31a6c-b37b-41ec-bdad-9d1141ea0bb2)
+
+# Formatting
+
+## Sort imports
+
+If you're using the brighterscript [import](https://github.com/rokucommunity/brighterscript/blob/master/docs/imports.md) feature, the VSCode extension and brighterscript-formatter are now able to sort imports alphabetically. Just be sure to set `"sortImports": true` in your `bsfmt.json` or set `"brightscript.format.sortImports": true` in your vscode settings. ([#75](https://github.com/RokuCommunity/brighterscript-formatter/pull/75))
+
+Here's the feature in action:
+
+![format-imports](https://github.com/rokucommunity/brighterscript-formatter/assets/2544493/2b4b179c-a76d-498d-815f-8673201956d1)
+
+# BrighterScript
+
+## Fix tab issue when printing diagnostics
+
+If your development team prefers to use tabs in your source code (instead of spaces), you may have noticed that sometimes the diagnostics printed in the console by bsc are not properly formatted. [#f616265](https://github.com/RokuCommunity/brighterscript/commit/f616265) fixes that now so everything should now line up properly!
+
+Before:
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/ecc9de19-1d94-469c-94f2-3eaef228de45)
+
+After (fixed!):
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/4541d735-6f5b-4098-b002-5f0c640527b2)
+
+## Print diagnostic related information
+
+Many BrighterScript diagnostics include related information (such as the path to a scope or file). These were showing in the vscode problems panel, but were surprisingly absent from `bsc` command-line interface. As of [brighterscript v0.65.5](https://github.com/rokucommunity/brighterscript/blob/master/CHANGELOG.md#0655---2023-09-06), the `bsc` cli will now print related information as well.
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/bd59ed7d-2054-4886-94dd-d25266fa548f)
+
+## Don't crash on null ranges
+
+This may not apply to most BrighterScript _users_, but for brighterScript plugin authors, we now more gracefully handle when brighterscript plugins inject AST that is missing `.range` properties. (yay, no more crashes...we hope 🤞) ([#869](https://github.com/RokuCommunity/brighterscript/pull/869))
+
+## Consistent insertion of bslib.brs
+
+To reduce code duplication, brighterscript injects the `bslib.brs` script into most SceneGraph complent xml, which includes several common library functions used to support features like the [ternary operator](https://github.com/rokucommunity/brighterscript/blob/master/docs/ternary-operator.md) or [template strings](https://github.com/rokucommunity/brighterscript/blob/master/docs/template-strings.md). We discovered some issues where the script would randomly be injected into certain unexpected components. We've fixed the randomness, so the scripts are now inserted in a much more predictable manner. ([#870](https://github.com/RokuCommunity/brighterscript/pull/870))
+
+## Allow specifying bslib destination directory
+
+There's a new option in brighterscript called `bslibDestinationDir` which you can use to specify what directory you want `bslib.brs` to be written to. This can be useful when dealing with complex brighterscript library projects. ([#871](https://github.com/RokuCommunity/brighterscript/pull/871))
+
+**bsconfig.json**
+
+```jsonc
+{
+    "rootDir": "./src",
+    "bslibDestinationDir": "./dist/roku_modules/bslib"
+}
+```
+
+## new `noproject` cli flag
+
+There are situations where you might want to run the brighterscript CLI without loading a `bsconfig.json` even though it's present. Historically, you had to do some hacky workarounds like specifying a path to a non-existent file:
+
+```bash
+npx bsc --project "not-there.json"
+```
+
+Thanks to [brighterscript#868](https://github.com/RokuCommunity/brighterscript/pull/868), you can now specify `--noproject` to explicitly disable `bsconfig.json` loading. This will also force any `--project` flag to be completely ignored. Here's how you use it:
+
+```bash
+npx bsc --noproject
+```
+
+## bs_const support in bsconfig.json
+
+You can now add a `bs_const` property to your `bsconfig.json`. **NOTE:** these do not update the output manifest file, but they will impact the conditional compile items, allowing for a more consistent editing experience. ([#887](https://github.com/RokuCommunity/brighterscript/pull/887))
+
+We hope to eventually have these values be included in the generated ouptput manifest, but that will need to wait until the [file api](https://github.com/rokucommunity/brighterscript/pull/408) lands in the mainline branch.
+
+**bsconfig.json**
+
+```jsonc
+{
+    "rootDir": "./src",
+    "bs_const": {
+        "DEBUG": true,
+        "ENABLE_DEBUG_LOGGING": true
+    }
+}
+```
+
+## Add missing `emitDefinitions` to docs
+
+BrighterScript has supported emitting type definitions (similar to [TypeScript's Type Declarations](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html#built-in-type-definitions)) for years now, but it was completely missing from the docs. We've fixed that! ([#893](https://github.com/RokuCommunity/brighterscript/pull/893))
+
+Type definitions are super useful if you're writing a library in brighterscript, but then distributing your library as brightscript code. The type definitions will support describing the way your code was originally written so that other brighterscript projects will be able to get better type validation.
+
+**someFile.d.bs**
+
+```vb
+namespace player
+   enum PlayState
+      playing
+      paused
+   end enum
+
+   sub play(video as VideoMetadata)
+   end sub
+
+   sub pause(video as VideoMetadata)
+   end sub
+
+   interface VideoMetadata
+      url as string
+      subtitleUrl as string
+   end interface
+end namespace
+```
+
+## Fix template string position bug
+
+We fixed a bug in the brighterscript [template string](https://github.com/rokucommunity/brighterscript/blob/master/docs/template-strings.md) transpiler that was incorrectly calculating line and column numbers, which caused poor debugging experiences because the source maps were then incorrect as well. This has been fixed, so template strings should no longer cause frustrating line offets while debugging! ([#921](https://github.com/RokuCommunity/brighterscript/pull/921))
+
+```typescript
+console.log(`
+    yay, I don't mess up line numbers
+    anymore
+`);
+```
+
+## Update plugins docs
+
+We've added new information to the BrighterScript plugins documentation related to modifying the bsconfig values after the project has loaded ([#913](https://github.com/RokuCommunity/brighterscript/pull/913))'
+
+Here's an example brighterscript plugin example showing how to do exactly that:
+
+```typescript
+import { CompilerPlugin, ProgramBuilder } from 'brighterscript';
+
+export default function plugin() {
+    return {
+        name: 'addFilesDynamically',
+        beforeProgramCreate: (builder: ProgramBuilder) => {
+            if (!builder.options.files) {
+                builder.options.files = [];
+            }
+
+            builder.options.files.push({
+                src: 'path/to/plugin/file.bs',
+                dest: 'some/destination/path/goes/here'
+            });
+        }
+    } as CompilerPlugin;
+}
+```
+
+# BrighterScript Preview features
+
+This month we're giving the brighterscript v0.66 branch its own entire section, because there has been a _LOT_ of significant progress made. Almost all of this work has been implemented by [@markwpearce (Mark Pearce)](https://github.com/markwpearce), who is doing an incredible job moving us closer to the finish line.
+
+You can try most of these out by installing the latest v0.66 alphas:
+
+```bash
+npm install brighterscript@next
+```
+
+## bslint
+
+We've started migrating bslint to the new BrighterScript v0.66 alphas. It's a work in progress, but hopefully here soon we'll have a version that is functional. In the mean time, you'll need to disable bslint in the `plugins` section of your `bsconfig.json` because it will cause runtime errors.
+
+Here are few of the PRs that went into prepping the project:
+
+-   bslint (2023-07-27): brighterscript@0.66.0-alpha.4 ([c495fb9](https://github.com/RokuCommunity/bslint/commit/c495fb9))
+-   bslint (2023-09-21): Add bsc-0.66-alpha.6. Fix tests ([5a4de6f](https://github.com/RokuCommunity/bslint/commit/5a4de6f))
+
+## Validate class and interface method calls
+
+We now validate class method calls!
+
+![image](https://user-images.githubusercontent.com/810290/256335937-ae33c514-f9ec-4e96-a8bc-d04e010f5293.png)
+
+<br />
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/fd820dd5-0211-439b-b8d3-9bfa646e8ed3)
+
+<br />
+
+![image](https://user-images.githubusercontent.com/810290/256336719-11daba64-77c3-4f02-abfd-6f25a5edacdf.png)
+
+## Type casts are not allowed in BrightScript
+
+In some of the initial v0.66 alphas, we accidentally allowed users to write type cast expressions (`thing as SomeType`) in plain brightscript projects. We now properly warn that the feature is only supported in BrighterScript.
+
+![image](https://user-images.githubusercontent.com/810290/256878508-7280d101-0214-4973-b961-fd727642b90a.png)
+
+## Fixed a hover bug
+
+We fixed a few bugs when hovering over certain types that was showing the wrong thing. Now we do a better job.
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/77498b0f-bc8b-460f-8a8e-9df8a720b88c)
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/3094917d-d741-47b6-85d0-2d47ca6bd406)
+
+## Return type validation
+
+We now validate the actual return type vs. the declared return type. Subs and void functions will have validation errors when an actual type is included, and this works in `.brs` _and_ `.bs` files!
+
+<video src="https://user-images.githubusercontent.com/810290/264360339-d065c1ee-30f2-496f-ad4d-2e66182b166b.mov" data-canonical-src="https://user-images.githubusercontent.com/810290/264360339-d065c1ee-30f2-496f-ad4d-2e66182b166b.mov" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px">
+</video>
+
+## Adds Typed Arrays
+
+Arrays can now have a type by defining them like `<type>[]` (e.g. `string[]` or `SomeClass[]`). We also support multidimensional arrays (e.g. `integer[][]`), as well as support overrides for built in methods for arrays (eg. `push()`, `pop()`) so it is consistent with the type. We will infer types from array literals as well, which can be very helpful for reducing needless `as <someType>` code.
+
+This feature is only available in BrighterScript.
+
+<video src="https://user-images.githubusercontent.com/810290/264099979-a32c8a12-73a6-4d16-8d01-6a95f91c5006.mov" data-canonical-src="https://user-images.githubusercontent.com/810290/264099979-a32c8a12-73a6-4d16-8d01-6a95f91c5006.mov" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px">
+</video>
+
+## Validates DottedSetStatements for type compatibility
+
+We can now assign a specific type to classes, which then allow us to validate type mismatches for class members.
+
+Line 3 should be an error because we're assigning an integer to a string.
+
+![image](https://user-images.githubusercontent.com/2544493/265223561-19fa45fd-3021-4010-bea2-58024a6206cd.png)
+
+## Adds Native Brightscript Component Types and Custom Components (Nodes) to Type System
+
+In order to significantly improve the type validation experience, we have now integrated all of the native BrightScript component types, SGNode types, and custom components into the type system. This will allow you to declare variables as those types, and then get a much richer editor experience and better type safety when you interact with those items. Here are some highlights:
+
+Additions:
+
+-   All native Brightscript Components (eg. `roDeviceInfo`, `roBitmap`, `roDateTime`, etc.) as types usable in Brighterscript, including completions on methods and documentation
+-   Same for native interfaces (`ifDraw2d`, `ifAppManager`, etc)
+-   Same for native events (`roInputEvent`, `roSGNodeEvent`)
+-   Adds `AssociativeArrayType` that can be built from an AA literal (eg. myAA = {name: "Mark", coolFactor: 100}), and will correctly be compatible with interface types that have declared the same members, eg:
+
+```vb
+interface Developer
+   name as string
+   coolFactor as integer
+end interface
+
+sub takesDeveloper(dev as Developer)
+   print dev
+end sub
+
+sub foo()
+   ' no validation error, because AA meets required interface
+   takesDeveloper({name: "Mark", coolFactor: 100})
+end sub
+```
+
+We have added SceneGraph nodes to type system. The type's name is the component's name prefixed with roSGNode ... so `roSGNodePoster`, `roSGNodeRowList`, `roSGNodeStdDlgTextItem` are all available as types (with completions, documentation, etc)
+
+Custom components are also added (again, prefixed with `roSgNode`). Eg:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="Widget" extends="Group">
+    <interface>
+        <field id="alpha" type="assocArray" />
+        <field id="beta" type="float" />
+        <field id="charlie" type="nodeArray" />
+    </interface>
+</component>
+```
+
+This will create a type in the type system with name `roSGNodeWidget`, with completions and type inferences for properties alpha, beta, charlie, as well as validation on methods like `getChildren()`, `subType()`, etc.
+
+## Adds validation for binary operators
+
+Adding string and number now gets flagged as a compile error. ([#896](https://github.com/RokuCommunity/brighterscript/pull/896))
+
+![image](https://user-images.githubusercontent.com/810290/268829734-a6c8c704-2bfd-4739-90ed-cfb4d104f56d.png)
+
+## Add interface parameter support
+
+Somehow when we were implementing brighterscript `interfaces`, we forgot to support parameters in function declarations. That has now been fixed, so you can property define your functions parameters in interfaces.
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/e94251c8-61fd-47ab-8e6b-a2859ecb9056)
+
+## Fixed issues with interface validations
+
+We've fixed several issues around validation interface usage, as well as adding extra details about missing or mismatched members:
+
+![image](https://github.com/rokucommunity/brighterscript/assets/810290/a34595d8-4702-41ac-9b7b-1c97e0ef68d4)
+
+## BrighterScript 0.66 alpha changes for plugin authors
+
+This section is still related to the 0.66 alphas, but focuses on BrighterScript plugin authors and how they interact with the BrighterScript lifecycle and AST.
+
+### Add Leading Trivia to all tokens as a way to get comments from expressions
+
+As plugin authors, you may sometimes want to know about leading/trailing comments for a given expression or token. [brighterscript#885](https://github.com/RokuCommunity/brighterscript/pull/885) introduces a concept of "leading trivia" which will currently just contain leading comments. Function, class, method, field, interface, namespace statements return valid data from getLeadingTrivia() function. This should work with annotations as well.
+
+Here's an example showing how to get all comment statements for the first function in the file
+
+```typescript
+import { Parser, TokenKind } from 'brighterscript';
+const parser = Parser.parse(`
+   'writes a message to the console
+   sub consoleLog(message)
+      print message
+   end sub
+`);
+
+const trivia = this.ast.findChild(isFunctionStatement).getLeadingTrivia();
+const comments = trivia.filter((x) => x.kind === TokenKind.Comment);
+```
+
+## Fixed `isLiteralInvalid` reflection method and added other `isLiteral*` methods
+
+BrighterScript plugin authors can leverage the `isLiteral*` methods to make certain decisions about the AST they are interacting with. As a result of adding the type system, several of these methods got broken. We've fixed them, and also added any missing methods for types. ([#902](https://github.com/RokuCommunity/brighterscript/pull/902))
+
+## Use Symbol Tables for Completions
+
+Historically the completions logic was fairly involved to write and maintain, because we were doing very specific lookups against specific AST items. With the new symbol table and type system, that can be significantly simplified, while also being far more accurate.
+
+There's not really a screenshot or demo to show with this, but just know that the completions are now much more maintainable and should more easily adapt to the changing type system.
+
+# Thank you
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
+
+Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
+
+-   [@triwav (Brian Leighty)](https://github.com/triwav)
+    -   Updated Node Detail Page in Scenegraph Node Inspector and Added Roku Test Automation Panel ([PR #499](https://github.com/RokuCommunity/vscode-brightscript-language/pull/499))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Update stopDebuggerOnAppExit description related to debug protocol. ([PR #497](https://github.com/RokuCommunity/vscode-brightscript-language/pull/497))
+
+Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
+
+-   [@chrisdp (Christopher Dwyer-Perkins)](https://github.com/chrisdp)
+    -   Task/support bs const in bsconfig ([PR #887](https://github.com/RokuCommunity/brighterscript/pull/887))
+-   [@enthooz (Andrew Ashbacher)](https://github.com/enthooz)
+    -   ensure consistent insertion of bslib.brs ([PR #870](https://github.com/RokuCommunity/brighterscript/pull/870))
+    -   allow optionally specifying bslib destination directory ([PR #871](https://github.com/RokuCommunity/brighterscript/pull/871))
+-   [@josephjunker (Joseph Junker)](https://github.com/josephjunker)
+    -   Add some more details to the plugins docs ([PR #913](https://github.com/RokuCommunity/brighterscript/pull/913))
+-   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
+    -   Adds built in Interfaces to primitive types & Validates class method calls ([PR #856](https://github.com/RokuCommunity/brighterscript/pull/856))
+    -   Type casts are not allowed in BrightScript ([PR #859](https://github.com/RokuCommunity/brighterscript/pull/859))
+    -   Fixes small hover issues ([PR #860](https://github.com/RokuCommunity/brighterscript/pull/860))
+    -   Fixes ReferenceTypes in Binary Operations & UnionTypes as args ([PR #858](https://github.com/RokuCommunity/brighterscript/pull/858))
+    -   Refactor Completions logic to be centralized to CompletionsProcessor ([PR #864](https://github.com/RokuCommunity/brighterscript/pull/864))
+    -   Fix built in methods parameter types ([PR #866](https://github.com/RokuCommunity/brighterscript/pull/866))
+    -   Fixed lint error ([8926e60](https://github.com/RokuCommunity/brighterscript/commit/8926e60))
+    -   Fixes types on call expression info class ([PR #877](https://github.com/RokuCommunity/brighterscript/pull/877))
+    -   Narrows some types ([6429017](https://github.com/RokuCommunity/brighterscript/commit/6429017))
+    -   Removed unneeded comment ([adfd5bd](https://github.com/RokuCommunity/brighterscript/commit/adfd5bd))
+    -   Fixed getting xml attribute location in diagnostic printing ([68c7c23](https://github.com/RokuCommunity/brighterscript/commit/68c7c23))
+    -   Adds Return type validation ([PR #876](https://github.com/RokuCommunity/brighterscript/pull/876))
+    -   Adds Typed Arrays ([PR #875](https://github.com/RokuCommunity/brighterscript/pull/875))
+    -   Adds Leading Trivia to all tokens, as a way to get comments from expressions ([PR #885](https://github.com/RokuCommunity/brighterscript/pull/885))
+    -   Use Symbol Tables for Completions ([PR #874](https://github.com/RokuCommunity/brighterscript/pull/874))
+    -   Validates DottedSetStatements for type compatibility ([PR #894](https://github.com/RokuCommunity/brighterscript/pull/894))
+    -   Adds Native Brightscript Component Types and Custom Components (Nodes) to Type System ([PR #891](https://github.com/RokuCommunity/brighterscript/pull/891))
+    -   Adds validation for binary operators ([PR #896](https://github.com/RokuCommunity/brighterscript/pull/896))
+    -   Fix union type unary operations and Array.sort(by) optional params ([PR #897](https://github.com/RokuCommunity/brighterscript/pull/897))
+    -   Fixes issues with Interface validations, and adds extra details about missing or mismatches members ([PR #901](https://github.com/RokuCommunity/brighterscript/pull/901))
+-   [@philanderson888 (Phil Anderson)](https://github.com/philanderson888)
+    -   add noProject flag to bsc so BSConfig.json not expected ([PR #868](https://github.com/RokuCommunity/brighterscript/pull/868))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix tab issue when printing diagnostics ([f616265](https://github.com/RokuCommunity/brighterscript/commit/f616265))
+    -   Add scopes to argumentTypeMismatch diagnostics ([8e0ff98](https://github.com/RokuCommunity/brighterscript/commit/8e0ff98))
+    -   Fix tab issue when printing diagnostics ([PR #865](https://github.com/RokuCommunity/brighterscript/pull/865))
+    -   Print diagnostic related information ([PR #867](https://github.com/RokuCommunity/brighterscript/pull/867))
+    -   Fix crashes in util for null ranges ([PR #869](https://github.com/RokuCommunity/brighterscript/pull/869))
+    -   Add missing emitDefinitions to docs and fix iface ([PR #893](https://github.com/RokuCommunity/brighterscript/pull/893))
+    -   Support defining params in interfaces ([PR #900](https://github.com/RokuCommunity/brighterscript/pull/900))
+    -   Fix isLiteralInvalid ([PR #902](https://github.com/RokuCommunity/brighterscript/pull/902))
+    -   Fix UnaryExpression transpile for ns and const ([PR #914](https://github.com/RokuCommunity/brighterscript/pull/914))
+    -   Fix incorrect quasi location in template string ([PR #921](https://github.com/RokuCommunity/brighterscript/pull/921))
+    -   fix bug in --noproject flag logic ([PR #922](https://github.com/RokuCommunity/brighterscript/pull/922))
+
+Contributions to [brighterscript-formatter](https://github.com/RokuCommunity/brighterscript-formatter):
+
+-   [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
+    -   Sort imports ([PR #75](https://github.com/RokuCommunity/brighterscript-formatter/pull/75))
+
+Contributions to [bslint](https://github.com/RokuCommunity/bslint):
+
+-   [@elsassph (Philippe Elsass)](https://github.com/elsassph)
+    -   Silence one bsc diagnostic ([8c49713](https://github.com/RokuCommunity/bslint/commit/8c49713))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   brighterscript@0.66.0-alpha.4 ([c495fb9](https://github.com/RokuCommunity/bslint/commit/c495fb9))
+    -   Add bsc-0.66-alpha.6. Fix tests ([5a4de6f](https://github.com/RokuCommunity/bslint/commit/5a4de6f))
+
+Contributions to [brs](https://github.com/RokuCommunity/brs):
+
+-   [@lvcabral (Marcelo Cabral)](https://github.com/lvcabral)
+    -   Fixed `val()` edge cases: hex without radix and `NaN` ([94304cd](https://github.com/RokuCommunity/brs/commit/94304cd))
+    -   Fixed prettier and replaced deprecated `substr()` method ([a223c2a](https://github.com/RokuCommunity/brs/commit/a223c2a))
+    -   Merge pull request #3 from rokucommunity/bugfix/string-val-function-not-compliant ([afca557](https://github.com/RokuCommunity/brs/commit/afca557))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   refactor in preparation for adoption the project ([d786413](https://github.com/RokuCommunity/brs/commit/d786413))
+    -   fix build script name ([fbaaed7](https://github.com/RokuCommunity/brs/commit/fbaaed7))
+    -   install node modules first ([2ccec94](https://github.com/RokuCommunity/brs/commit/2ccec94))
+    -   break out tasks to view nicer failure spot ([53c1aeb](https://github.com/RokuCommunity/brs/commit/53c1aeb))
+    -   Add coverage reporting ([817c651](https://github.com/RokuCommunity/brs/commit/817c651))
+    -   Actually add coverage reporting ([e31226b](https://github.com/RokuCommunity/brs/commit/e31226b))
+    -   fix coverage reporting ([b2d223a](https://github.com/RokuCommunity/brs/commit/b2d223a))
+    -   Merge pull request #1 from rokucommunity/adoption ([f1546e3](https://github.com/RokuCommunity/brs/commit/f1546e3))
+    -   Update README.md ([ec82a06](https://github.com/RokuCommunity/brs/commit/ec82a06))
+    -   Add changelog ([f72f2dc](https://github.com/RokuCommunity/brs/commit/f72f2dc))
+    -   Add note about the project fork. ([af0c223](https://github.com/RokuCommunity/brs/commit/af0c223))
+    -   Make tests import relative path to lib/index.js ([202cc9f](https://github.com/RokuCommunity/brs/commit/202cc9f))

--- a/src/pages/whats-new/2023-09-September.md
+++ b/src/pages/whats-new/2023-09-September.md
@@ -421,6 +421,8 @@ Contributions to [bslint](https://github.com/RokuCommunity/bslint):
 -   [@elsassph (Philippe Elsass)](https://github.com/elsassph)
     -   Silence one bsc diagnostic ([8c49713](https://github.com/RokuCommunity/bslint/commit/8c49713))
 -   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix event structure ([61481e1](https://github.com/RokuCommunity/bslint/commit/61481e1))
+    -   Performance boost by lifting some global lookups ([81aa853](https://github.com/RokuCommunity/bslint/commit/81aa853))
     -   brighterscript@0.66.0-alpha.4 ([c495fb9](https://github.com/RokuCommunity/bslint/commit/c495fb9))
     -   Add bsc-0.66-alpha.6. Fix tests ([5a4de6f](https://github.com/RokuCommunity/bslint/commit/5a4de6f))
 

--- a/src/pages/whats-new/2023-10-October.md
+++ b/src/pages/whats-new/2023-10-October.md
@@ -327,8 +327,8 @@ Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
 
 -   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    -   Fixes some enum validation stuff ([PR #920](https://github.com/RokuCommunity/brighterscript/pull/920))
     -   Allow classes and native components in Typed Arrays ([PR #919](https://github.com/RokuCommunity/brighterscript/pull/919))
+    -   Fixes some enum validation stuff ([PR #920](https://github.com/RokuCommunity/brighterscript/pull/920))
     -   Fixes compatibility of built in types (roArray -> typed arrays) ([PR #925](https://github.com/RokuCommunity/brighterscript/pull/925))
     -   Semantic Tokes for Native Components and Type completion in Type Expressions ([PR #927](https://github.com/RokuCommunity/brighterscript/pull/927))
     -   Adds `callFunc` as member method to Custom Components ([PR #929](https://github.com/RokuCommunity/brighterscript/pull/929))

--- a/src/pages/whats-new/2023-10-October.md
+++ b/src/pages/whats-new/2023-10-October.md
@@ -356,5 +356,3 @@ Contributions to [bslint](https://github.com/RokuCommunity/bslint):
 -   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
     -   copy expectDiagnostics from brighterscript for tests ([PR #95](https://github.com/RokuCommunity/bslint/pull/95))
     -   Fixing issues before release 0.8.11 ([051fd4c](https://github.com/RokuCommunity/bslint/commit/051fd4c))
--   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    -   Fixes for BrighterScript Typing-Phase-1 breaking changes ([53f8f9c](https://github.com/RokuCommunity/bslint/commit/53f8f9c))

--- a/src/pages/whats-new/2023-10-October.md
+++ b/src/pages/whats-new/2023-10-October.md
@@ -1,0 +1,360 @@
+---
+date: October 2023
+summary: Changes to vscode-brightscript-language, brighterscript, roku-debug, brighterscript-formatter, bslint, ropm, roku-report-analyzer
+layout: ../../layouts/WhatsNewPost.astro
+---
+
+# Overview
+
+This month has seen some very significant improvements to the brighterscript type tracking initiative, and a complete overhaul of the internals of the debug session logic, as well as many other smaller changes to bslint, the formatter, and the vscode extension. Many thanks to all who have worked so hard and contributed this month!
+
+## We need your help
+
+The RokuCommunity projects are maintained by a relatively small group of developers (mostly volunteers), and we have a growing list of of unresolved issues. We need your help! There are many different ways you can contribute. Whether it's addressing bugs, improving documentation, introducing new features, or simply helping us manage our expanding list of GitHub issues, your involvement would be greatly appreciated. We are more than happy to guide you in finding the most suitable contribution method that aligns with your interests. To learn more about how you can contribute, feel free to reach out to us on [Slack](https://join.slack.com/t/rokudevelopers/shared_invite/zt-4vw7rg6v-NH46oY7hTktpRIBM_zGvwA), or explore the existing GitHub issues:
+
+-   [vscode-brightscript-language](https://github.com/rokucommunity/vscode-brightscript-language/issues)
+-   [brighterscript](https://github.com/rokucommunity/brighterscript/issues)
+-   [brighterscript-formatter](https://github.com/rokucommunity/brighterscript-formatter/issues)
+-   [roku-deploy](https://github.com/rokucommunity/roku-deploy/issues)
+-   [roku-debug](https://github.com/rokucommunity/roku-debug/issues)
+-   [bslint](https://github.com/rokucommunity/bslint/issues)
+-   [ropm](https://github.com/rokucommunity/ropm/issues)
+
+## Issue of the month
+
+In this section, we highlight a specific issue where we could benefit from the community's assistance in finding a solution. These problems are generally straightforward to address, and serve as an excellent opportunity to become acquainted with the RokuCommunity codebases.
+
+This month, we'd like to draw attention to [vscode-brightscript-language#470](https://github.com/rokucommunity/vscode-brightscript-language/issues/470). BrighterScript has support for regular expressions, so we added some syntax highlighting to help make those stand out more. However, there's a bug in the syntax logic, and it's incorrectly treating valid math expressions like they're regex expressions.
+
+![image](https://user-images.githubusercontent.com/2544493/226361636-1078820c-9b26-4a1f-b5fd-377508ac5796.png)
+
+We'd like to get that fixed so math looks right again!
+
+# Editor
+
+## Align device picker name with name from the devices tab
+
+We standardized the device names in the device picker to match the names from the devices tree view panel. We now use the user-defined name when available.
+
+Before:
+
+![image](https://user-images.githubusercontent.com/2544493/274648905-fd473bd8-957d-42dc-aa34-eeecb61a14ab.png)
+
+After:
+
+![image](https://user-images.githubusercontent.com/2544493/274648768-ad97a8c3-507a-411d-bb4f-d5fae360b582.png)
+
+## Enhance host picker during launch
+
+We've significantly improved the experience interacting with the device picker dropdown that is shown when using the `"${promptForHost}"` option when launching a debug session:
+
+-   add "last used" separator for the last used device
+-   add "devices/other devices" separator for devices not last used
+-   add separator line to separate the "enter manually" option
+-   refresh the list any time a new device is discovered, instead of a blanket "wait 5 seconds" that was there previously
+-   show a loader when we think there are more devices to be discovered
+
+Here's a preview of the feature:
+
+![image](https://user-images.githubusercontent.com/2544493/279407208-4fa3ce2e-5005-4919-8a16-645fa3b4a6f9.gif)
+
+We've started dreaming up some fairly significant enhancements to the concept of "active devices". You can read about them [here](https://github.com/rokucommunity/vscode-brightscript-language/issues/506). We'd appreciate any feedback or insight you might have into the design of the feature.
+
+## Add link for ECP registry
+
+A new "View Registry" entry has been added to the devices panel that will open the dev channel's registry in a web browser (if your device supports it).
+
+Next month we'll be adding the ability to pick what channel you want to view the registry for (instead of always defaulting to the dev channel), so stay tuned.
+
+![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/9c2f7ef4-666f-4bf9-b994-dfadd5d7cc26)
+
+# Debugging
+
+## Enable remote control on launch
+
+A new launch setting called `remoteControlMode` has been added. This will allow you to automate the [remote control mode](https://rokucommunity.github.io/vscode-brightscript-language/Debugging/remote-control-mode.html). You can configure `activateOnSessionStart` and `deactivateOnSessionEnd` independently to fully customize how you want the feature to work. Check it out!
+
+We'd like to give kudos to [@iBicha (Brahim Hadriche)](https://github.com/iBicha) for the awesome work on this feature, as it was highlighted in our [June 2023](http://localhost:3000/whats-new/2023-06-June) edition as the [Issue of the month](http://localhost:3000/whats-new/2023-06-June#issue-of-the-month).
+
+![remoteControlMode](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/da1d55c5-a9bf-44c2-8c74-ab2436244eb3)
+
+## Fix automation view crash when no config found
+
+We fixed a bug in the automation view panel where it would crash if there was no config defined. Users could easily encounter this bug if they had never set any custom automation values.
+
+Before the fix:
+
+![image](https://user-images.githubusercontent.com/2544493/271679563-f23df431-938b-4a55-a30f-7d1747eb015f.png)
+
+After the fix: ....it just works. 😀
+
+## Fix that pesky "local variables" spinner in telnet
+
+A common issue lately with the telnet debugger is that it gets in these strange "stuck" states, where the local variables panel seems to load infinitely. Like this:
+
+![local-spin](https://github.com/rokucommunity/logger/assets/2544493/4d6e299f-52c0-435c-b511-884b957513b4)
+
+The telnet debugger is extremely brittle. This is because we essentially wrote a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) output log scraping state machine. Roku changing even a single character of their telnet output logs puts us at risk of falling into an unstable state.
+
+We've [fixed a few issues](https://github.com/RokuCommunity/roku-debug/pull/163) related to this, so the telnet debugger should be a bit more stable now. Please [raise an issue](https://github.com/rokucommunity/roku-debug/issues) if you encounter any more of these unstable situations.
+
+## Debug Protocol Enhancements
+
+We've finally landed a significant refactor of our debugger after working on it for over a year (it wasn't nonstop, but still took a while...).
+
+Code that interacts with a Roku device directly is typically very difficult to unit test. To mitigate that, we created a debug protocol server which emulates the server-side of Roku's binary debug protocol. This vastly simplifies the unit test experience, as we can now control both the client side and the server side, mocking both if necessary.
+
+The one caveat is that these are not on-device tests, but the majority of our logic can be tested in this fashion. This `DebugProtocolServer` can also be used to provide actual debugging experiences in a brs emulator (if someone ever gets around to implementing that...).
+
+Each ProtocolRequest and ProtocolResponse class will support loading from json, loading from a buffer, and serializing to a buffer. This makes the binary structures for client and server first-class citizens of the project, and simplifies the unit test experience as well. For the average user, this should result in a much more consistent debugging experience, and less frequent breaking changes as we release updates.
+
+You can check out the [roku-debug#107](https://github.com/RokuCommunity/roku-debug/pull/107) if you're interested in reviewing the 17,000 lines of added/changed/removed code.
+
+## Better compile error handling
+
+Our compile error handling broke sometime in the last year or two. We used to highlight the line that had the error, but lately it just silently fails and only sometimes shows the error in the output logs.
+
+This month we released some significant improvements to that experience. Now when a debug session detects a compile error, we will highlight the failed line in a similar style to runtime exceptions. We also keep the debug session alive, so you will need to click "stop" to terminate the session. This more closely aligns us with other debuggers like Node and dotnet. This works for both telnet _and_ the debug protocol.
+
+![compile-error](https://github.com/rokucommunity/roku-debug/assets/2544493/c1c144e8-f6ca-48bd-beb3-13c409795853)
+
+## Better debug session process cleanup
+
+Some of our users have been experiencing some high CPU usage after a debug session has ended. This seems to be caused by the roku-debug process not properly shutting down. This month we squashed several bugs related to that. We do a much better job cleaning up opened sockets, event listeners, telnet connections, etc.
+
+There's not much to show here, but hopefully we found all the areas that were blocking the process shutdown. Please [raise an issue](https://github.com/rokucommunity/roku-debug/issues) if you encounter any more of these unstable situations.
+
+# Formatting
+
+## new `color-format` bslint rule to enforce specific color formats
+
+We've added several new bslint rules to enforce specific color formats in your code. Here are some of the details:
+
+-   `color-format`: ensures that all the color values follow the same prefix formatting. Can also use to prevent any colors values from being defined in the code-base (brs or bs files), except for values in a stand-alone file (ie. theme file).
+
+    -   `hash-hex`: enforces all color values are type string or template string and use a `#` prefix
+    -   `quoted-numeric-hex`: enforces all color values are type string or template string and use a `0x` prefix
+    -   `never`: enforces that no color values can be defined in the code-base (brs or bs files). Useful if you define colors in a separate stand-alone file. To use this option you would list your stand-alone file in the `ignore` list or `diagnosticFilters`.
+    -   `off`: do not validate (**default**)
+
+You can also specify some other settings such as `color-case` to enforce upper-case or lower-case characters, `color-alpha` to require alpha to be defined (or not defined), and `color-cert` to enforce Roku's [broadcast safe color 6.4 certification requirement](https://developer.roku.com/en-gb/docs/developer-program/certification/certification.md)
+
+# BrighterScript
+
+# BrighterScript Preview features
+
+This month we're giving the brighterscript v0.66 branch its own entire section again, because there has been a _LOT_ of significant progress made. Almost all of this work has been implemented by [@markwpearce (Mark Pearce)](https://github.com/markwpearce), who is doing an incredible job moving us closer to the finish line.
+
+You can try most of these out by installing the latest v0.66 alphas:
+
+```bash
+npm install brighterscript@next
+```
+
+## File api
+
+At long last, the file api has been merged! (into the upcoming v0.66 release branch). We had hoped to land this in mainline back in the spring, but there were a few breaking changes that we had to work through. Since v0.66 will bring several other breaking changes, it made more sense to go ahead and group the file API changes in with that release. We won't get into too much detail on the file api, but here are some highlights:
+
+-   all files matched by the `files` array are now loaded into the program. Known files (like `xml` and `brs`/`bs` will be handled by BrighterScript, and all other files will be passed through as-is.
+-   plugins can now intercept the `provideFile` plugin hook and contribute their own enriched files (like json validation, non-scenegraph xml support, etc).
+
+You can review pull request at [brighterscript#408](https://github.com/RokuCommunity/brighterscript/pull/408), or read the file api docs [here](https://github.com/rokucommunity/brighterscript/blob/release-0.66.0/docs/plugins.md#file-api)
+
+Also note that this feature is still in preview. We may still need to make some changes to the API as developers start to more heavily leverage the file API, so just keep that in mind.
+
+## Support overloaded methods in BrightScript interfaces
+
+In order to keep the native scenegraph/brightscript data up-to-date, we regularly maintain a JSON file of all the various built-in types provided by the Roku platform. We have added support for BrightScript interface method overloads so that there is now a single definition of the method that can be added to the type system. We also fixed some incorrect function signatures like `array.sort()` `flags` param being optional.
+
+![image](https://user-images.githubusercontent.com/810290/275030780-0d37c1a2-c39b-47b2-80c9-404563f8371a.png)
+
+<br />
+
+![image](https://user-images.githubusercontent.com/810290/275031209-cbd8802a-1552-44d4-b693-8ff7ba12484a.png)
+
+## Adds `callFunc` as member method to Custom Components
+
+The type system now supports adding callfunc members to custom components. This will allow us to detect when an unknown function is callfunc'd.
+
+## Semantic Tokes for Native Components and Type completion in Type Expressions
+
+We added support for better semantic token highlighting for component types and interfaces:
+
+![image](https://user-images.githubusercontent.com/810290/272982938-c2b0fa22-e5f5-4360-b874-add0c71c0b15.png)
+
+## Code completion in Type Cast/Type Expression:
+
+We've updated the code completions to now show all of the native interfaces.
+
+![image](https://user-images.githubusercontent.com/810290/272983536-547db5d2-1d6c-41b7-9aaf-a55d07d64213.png)
+
+## Fixes compatibility of built in types (roArray -> typed arrays)
+
+[brighterscript#925](https://github.com/RokuCommunity/brighterscript/pull/925) fixes some bugs in the type tracking related to assignability between `string` and `roString` and also when comparing typed arrays
+
+## Fixes enum validation
+
+Fixed a bug in enum validation where returning an integer-based enum value should not cause an error, as the value should be convertible. We also fixed a few issues where enums were not being properly treated as their underlying types when passed to functions.
+
+![image](https://github.com/rokucommunity/brighterscript/assets/2544493/1d260ab8-6c21-4abb-86a7-63eb44798698)
+
+## Allow classes and native components in Typed Arrays
+
+We [fixed](https://github.com/RokuCommunity/brighterscript/pull/919) a bug When you declare a type of native component array, (eg. roAssociativeArray[] or roBitmap[]) there is a validation error. The following issue should no longer be a problem:
+
+![image](https://user-images.githubusercontent.com/810290/269942800-689f5aad-b7e9-4779-976a-ad5283ccdbae.png)
+
+## Improve type compatibility diagnostic messages
+
+We've improved some of the "type a is not compatible with type b" messages. One change is that we now truncate the list of items with a `...and x more` message.
+
+Similar to typescript, this will show exclusively the "missing members" message if there are any missing members. Then, if there are no missing members, it'll show the "members are incompatible" message if there are any incompatible members. This helps reduce the size of these large errors in some codebases. You've got to address the missing members and the incompatible types, so it doesn't hurt to just show one at a time.
+
+combined error message before:
+
+![image](https://user-images.githubusercontent.com/2544493/269929286-eca96374-514b-4e33-91f0-13aeee469cad.png)
+
+Missing members after:
+
+![image](https://user-images.githubusercontent.com/2544493/269929455-f895e734-10a5-4e12-84fa-ed4bf1c185bb.png)1
+
+Incompatible members after:
+
+![image](https://user-images.githubusercontent.com/2544493/269929522-edecc769-3c18-4e16-8e05-74cd7be44ce0.png)
+
+## Better multi scope messages
+
+We improved the multi-scope diagnostic messaging for related infos more relevant (and concise). Also truncate that list since seeing 95 related infos is just noise...
+
+Here's how it looks now:
+
+![image](https://user-images.githubusercontent.com/2544493/269661562-1e216018-5607-4e53-bb71-8d0c5a322ada.png)
+
+## Fixed some bugs in hovers
+
+Adds more incomplete expressions to the AST, so they can be used for completions.
+
+Fixes:
+
+-   Union type completions are only symbols available in all types Completion on union type should only show shared properties
+-   Array toString() uses default type Reduce like types for hovers
+-   Fixes Enum completions and hovers Completions for enum is wrong
+
+You can read more about it here: [brighterscript#874](https://github.com/RokuCommunity/brighterscript/pull/874)
+
+## Wider support for `as object`
+
+We've fixed some type validation issues related to `as object` variable types. They are permitted to be passed to any function type (just like dynamic), so we've fixed a bug that was marking those as errors.
+
+## Various other type validation enhancements
+
+-   BinaryExpressions and UnaryExpressions should be able to infer resultant types (eg. Integer \* Integer => Integer, String + String => String, etc.)
+
+-   Change Hover & Completion to use SymbolTable instead of variableDeclarations/callables
+
+This will complete the refactor to move away from using these lookup tables to unify how a symbol can be discovered/known. When this is done, the concept of VariableDeclarations can be removed from the code.
+
+-   Validate function calls for argument type validity
+
+Function argument equality
+
+```vb
+sub main()
+    printMessage(1)
+    '            ~ Argument of type 'number' is not assignable to parameter of type 'string'
+end sub
+
+function printMessage(message as string)
+    print message
+end function
+```
+
+## Better diagnostic ranges for unknown dotted get expressions
+
+We've tightened the range for the "can't find this property" diagnostics so it only highlights the property instead of the entire starting expression.
+
+Before:
+
+![image](https://user-images.githubusercontent.com/2544493/244416322-846b23f8-83a0-47ce-a52d-9da0983c2301.png)
+
+After:
+
+![image](https://user-images.githubusercontent.com/2544493/244416204-8d7d046a-56c0-4da4-8cea-9dbb89559431.png)
+
+## Adds .kind prop to AstNode.
+
+The `is<SomeAstNodeType>` functions from `reflections.ts` are used _heavily_ across brighterscript. As such, we found that this expression `thing?.constructor?.name === 'Whatever'` was fairly slow. To speed it up, we added a `.kind` property to `AstNode`, an `AstNodeKind` enum., and then converted the reflection methods to check for `.kind` instead of the `thing?.constructor?.name === 'Whatever'` logic. Raw benchmarks show this as a fairly significant boost:
+
+![image](https://user-images.githubusercontent.com/2544493/234745941-ecf12cfd-cb6b-4755-8497-ac03817fb38c.png)
+
+What that means in practice is validation speeds improve by 10-12 percent.
+
+![image](https://user-images.githubusercontent.com/2544493/234746091-cacae55f-a825-4007-91da-23b26a4e0c7f.png)
+
+Downsides:
+
+This is a breaking change, as all plugins that produce AST would need to be upgraded to the latest version of brighterscript in order to work with the version of brighterscript shipped with the vscode extension. Or, for example, latest version of brighterscript being used with a plugin that depends on an older version of brighterscript.
+
+## Breaking changes
+
+We've introduced some additional breaking changes to brighterscript as we move closer to the release of v0.66.0.
+
+-   all plugin event handler parameters have been converted single event objects. ([brighterscript#824](https://github.com/RokuCommunity/brighterscript/pull/824))
+-   several plugin event names have changed as a result of the file api. We've added warnings if your plugins use them, but plugins will need to update to the new names.
+-   the XML AST has been refactored to better support being modified by plugins during transpile. ([brighterscript#818](https://github.com/RokuCommunity/brighterscript/pull/818))
+-   the `.kind` property on AstNode has been added, and all the reflection methods exclusively check for that now ([#799](https://github.com/RokuCommunity/brighterscript/pull/799))
+
+# Thank you
+
+Last but certainly not least, a big **_Thank You_** to the following people who contributed this month:
+
+Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix automation view crash when no config found ([PR #504](https://github.com/RokuCommunity/vscode-brightscript-language/pull/504))
+    -   Fix error when generating the docs ([12dfb27](https://github.com/RokuCommunity/vscode-brightscript-language/commit/12dfb27))
+    -   Make device picker name same as tree view item ([PR #508](https://github.com/RokuCommunity/vscode-brightscript-language/pull/508))
+    -   Diagnostic manager ([PR #502](https://github.com/RokuCommunity/vscode-brightscript-language/pull/502))
+    -   Enhance host picker during launch ([PR #512](https://github.com/RokuCommunity/vscode-brightscript-language/pull/512))
+    -   Add brs to releases script ([5c6622b](https://github.com/RokuCommunity/vscode-brightscript-language/commit/5c6622b))
+-   [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
+    -   Enable remote control on launch ([PR #503](https://github.com/RokuCommunity/vscode-brightscript-language/pull/503))
+-   [@fumer-fubotv (fumer-fubotv)](https://github.com/fumer-fubotv)
+    -   Add ability to capture device screenshots ([PR #505](https://github.com/RokuCommunity/vscode-brightscript-language/pull/505))
+-   [@MilapNaik (Milap Naik)](https://github.com/MilapNaik)
+    -   Add link for ECP registry ([PR #511](https://github.com/RokuCommunity/vscode-brightscript-language/pull/511))
+
+Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Add interface parameter support ([PR #924](https://github.com/RokuCommunity/brighterscript/pull/924))
+    -   Better typing for `Deferred` ([PR #923](https://github.com/RokuCommunity/brighterscript/pull/923))
+    -   Fix stagingDir issue in transpiler test ([8a31693](https://github.com/RokuCommunity/brighterscript/commit/8a31693))
+    -   File api ([PR #408](https://github.com/RokuCommunity/brighterscript/pull/408))
+    -   ci: Don't run `test-related-projects` on release since it already ran on build ([157fc2e](https://github.com/RokuCommunity/brighterscript/commit/157fc2e))
+    -   Refine type compat message ([PR #908](https://github.com/RokuCommunity/brighterscript/pull/908))
+    -   Better multi scope messages ([PR #904](https://github.com/RokuCommunity/brighterscript/pull/904))
+-   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
+    -   Allows `scrape-roku-docs` to consolidate overloaded methods ([PR #930](https://github.com/RokuCommunity/brighterscript/pull/930))
+    -   Adds `callFunc` as member method to Custom Components ([PR #929](https://github.com/RokuCommunity/brighterscript/pull/929))
+    -   Semantic Tokes for Native Components and Type completion in Type Expressions ([PR #927](https://github.com/RokuCommunity/brighterscript/pull/927))
+    -   Fixes compatibility of built in types (roArray -> typed arrays) ([PR #925](https://github.com/RokuCommunity/brighterscript/pull/925))
+    -   Fixes some enum validation stuff ([PR #920](https://github.com/RokuCommunity/brighterscript/pull/920))
+    -   Allow classes and native components in Typed Arrays ([PR #919](https://github.com/RokuCommunity/brighterscript/pull/919))
+
+Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix bug with telnet getting stuck ([PR #163](https://github.com/RokuCommunity/roku-debug/pull/163))
+    -   Debug Protocol Enhancements ([PR #107](https://github.com/RokuCommunity/roku-debug/pull/107))
+    -   Clean up control socket when it's closed ([PR #166](https://github.com/RokuCommunity/roku-debug/pull/166))
+
+Contributions to [bslint](https://github.com/RokuCommunity/bslint):
+
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fixing issues before release 0.8.11 ([051fd4c](https://github.com/RokuCommunity/bslint/commit/051fd4c))
+    -   copy expectDiagnostics from brighterscript for tests ([PR #95](https://github.com/RokuCommunity/bslint/pull/95))
+-   [@disc7 (Charlie Abbott)](https://github.com/disc7)
+    -   [WIP] Color format checking for bslint ([PR #94](https://github.com/RokuCommunity/bslint/pull/94))
+-   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
+    -   Fixes for Brighterscript Typing-Phase-1 breaking changes ([53f8f9c](https://github.com/RokuCommunity/bslint/commit/53f8f9c))

--- a/src/pages/whats-new/2023-10-October.md
+++ b/src/pages/whats-new/2023-10-October.md
@@ -310,37 +310,37 @@ Last but certainly not least, a big **_Thank You_** to the following people who 
 
 Contributions to [vscode-brightscript-language](https://github.com/RokuCommunity/vscode-brightscript-language):
 
--   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    -   Fix automation view crash when no config found ([PR #504](https://github.com/RokuCommunity/vscode-brightscript-language/pull/504))
-    -   Fix error when generating the docs ([12dfb27](https://github.com/RokuCommunity/vscode-brightscript-language/commit/12dfb27))
-    -   Make device picker name same as tree view item ([PR #508](https://github.com/RokuCommunity/vscode-brightscript-language/pull/508))
-    -   Diagnostic manager ([PR #502](https://github.com/RokuCommunity/vscode-brightscript-language/pull/502))
-    -   Enhance host picker during launch ([PR #512](https://github.com/RokuCommunity/vscode-brightscript-language/pull/512))
-    -   Add brs to releases script ([5c6622b](https://github.com/RokuCommunity/vscode-brightscript-language/commit/5c6622b))
--   [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
-    -   Enable remote control on launch ([PR #503](https://github.com/RokuCommunity/vscode-brightscript-language/pull/503))
 -   [@fumer-fubotv (fumer-fubotv)](https://github.com/fumer-fubotv)
     -   Add ability to capture device screenshots ([PR #505](https://github.com/RokuCommunity/vscode-brightscript-language/pull/505))
+-   [@iBicha (Brahim Hadriche)](https://github.com/iBicha)
+    -   Enable remote control on launch ([PR #503](https://github.com/RokuCommunity/vscode-brightscript-language/pull/503))
 -   [@MilapNaik (Milap Naik)](https://github.com/MilapNaik)
     -   Add link for ECP registry ([PR #511](https://github.com/RokuCommunity/vscode-brightscript-language/pull/511))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Fix error when generating the docs ([12dfb27](https://github.com/RokuCommunity/vscode-brightscript-language/commit/12dfb27))
+    -   Fix automation view crash when no config found ([PR #504](https://github.com/RokuCommunity/vscode-brightscript-language/pull/504))
+    -   Diagnostic manager ([PR #502](https://github.com/RokuCommunity/vscode-brightscript-language/pull/502))
+    -   Make device picker name same as tree view item ([PR #508](https://github.com/RokuCommunity/vscode-brightscript-language/pull/508))
+    -   Add brs to releases script ([5c6622b](https://github.com/RokuCommunity/vscode-brightscript-language/commit/5c6622b))
+    -   Enhance host picker during launch ([PR #512](https://github.com/RokuCommunity/vscode-brightscript-language/pull/512))
 
 Contributions to [brighterscript](https://github.com/RokuCommunity/brighterscript):
 
--   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    -   Add interface parameter support ([PR #924](https://github.com/RokuCommunity/brighterscript/pull/924))
-    -   Better typing for `Deferred` ([PR #923](https://github.com/RokuCommunity/brighterscript/pull/923))
-    -   Fix stagingDir issue in transpiler test ([8a31693](https://github.com/RokuCommunity/brighterscript/commit/8a31693))
-    -   File api ([PR #408](https://github.com/RokuCommunity/brighterscript/pull/408))
-    -   ci: Don't run `test-related-projects` on release since it already ran on build ([157fc2e](https://github.com/RokuCommunity/brighterscript/commit/157fc2e))
-    -   Refine type compat message ([PR #908](https://github.com/RokuCommunity/brighterscript/pull/908))
-    -   Better multi scope messages ([PR #904](https://github.com/RokuCommunity/brighterscript/pull/904))
 -   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    -   Allows `scrape-roku-docs` to consolidate overloaded methods ([PR #930](https://github.com/RokuCommunity/brighterscript/pull/930))
-    -   Adds `callFunc` as member method to Custom Components ([PR #929](https://github.com/RokuCommunity/brighterscript/pull/929))
-    -   Semantic Tokes for Native Components and Type completion in Type Expressions ([PR #927](https://github.com/RokuCommunity/brighterscript/pull/927))
-    -   Fixes compatibility of built in types (roArray -> typed arrays) ([PR #925](https://github.com/RokuCommunity/brighterscript/pull/925))
     -   Fixes some enum validation stuff ([PR #920](https://github.com/RokuCommunity/brighterscript/pull/920))
     -   Allow classes and native components in Typed Arrays ([PR #919](https://github.com/RokuCommunity/brighterscript/pull/919))
+    -   Fixes compatibility of built in types (roArray -> typed arrays) ([PR #925](https://github.com/RokuCommunity/brighterscript/pull/925))
+    -   Semantic Tokes for Native Components and Type completion in Type Expressions ([PR #927](https://github.com/RokuCommunity/brighterscript/pull/927))
+    -   Adds `callFunc` as member method to Custom Components ([PR #929](https://github.com/RokuCommunity/brighterscript/pull/929))
+    -   Allows `scrape-roku-docs` to consolidate overloaded methods ([PR #930](https://github.com/RokuCommunity/brighterscript/pull/930))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   Better multi scope messages ([PR #904](https://github.com/RokuCommunity/brighterscript/pull/904))
+    -   Refine type compat message ([PR #908](https://github.com/RokuCommunity/brighterscript/pull/908))
+    -   Better typing for `Deferred` ([PR #923](https://github.com/RokuCommunity/brighterscript/pull/923))
+    -   Add interface parameter support ([PR #924](https://github.com/RokuCommunity/brighterscript/pull/924))
+    -   ci: Don't run `test-related-projects` on release since it already ran on build ([157fc2e](https://github.com/RokuCommunity/brighterscript/commit/157fc2e))
+    -   File api ([PR #408](https://github.com/RokuCommunity/brighterscript/pull/408))
+    -   Fix stagingDir issue in transpiler test ([8a31693](https://github.com/RokuCommunity/brighterscript/commit/8a31693))
 
 Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
 
@@ -351,10 +351,10 @@ Contributions to [roku-debug](https://github.com/RokuCommunity/roku-debug):
 
 Contributions to [bslint](https://github.com/RokuCommunity/bslint):
 
--   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
-    -   Fixing issues before release 0.8.11 ([051fd4c](https://github.com/RokuCommunity/bslint/commit/051fd4c))
-    -   copy expectDiagnostics from brighterscript for tests ([PR #95](https://github.com/RokuCommunity/bslint/pull/95))
 -   [@disc7 (Charlie Abbott)](https://github.com/disc7)
     -   [WIP] Color format checking for bslint ([PR #94](https://github.com/RokuCommunity/bslint/pull/94))
+-   [@TwitchBronBron (Bronley Plumb)](https://github.com/TwitchBronBron)
+    -   copy expectDiagnostics from brighterscript for tests ([PR #95](https://github.com/RokuCommunity/bslint/pull/95))
+    -   Fixing issues before release 0.8.11 ([051fd4c](https://github.com/RokuCommunity/bslint/commit/051fd4c))
 -   [@markwpearce (Mark Pearce)](https://github.com/markwpearce)
-    -   Fixes for Brighterscript Typing-Phase-1 breaking changes ([53f8f9c](https://github.com/RokuCommunity/bslint/commit/53f8f9c))
+    -   Fixes for BrighterScript Typing-Phase-1 breaking changes ([53f8f9c](https://github.com/RokuCommunity/bslint/commit/53f8f9c))


### PR DESCRIPTION
Fixes several issues with the whats-new generator script. It was incorrectly including commits outside of the releases for the given date range. 
 - adds more cli controls to make it easier to interact with when debugging.