### PR TITLE
Add clickable header links in whats-new

### DIFF
--- a/src/layouts/WhatsNewPost.astro
+++ b/src/layouts/WhatsNewPost.astro
@@ -112,5 +112,43 @@ const headings = thisPost?.getHeadings().filter((h) => h.depth < 3) ?? [];
                 );
             }
         </style>
+        <script>
+            const linkSvg = `
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-6 w-6"
+                    aria-hidden="true"
+                    focusable="false"
+                    stroke-width="1" stroke="currentColor"
+                    fill="none"
+                    stroke-linecap="round"
+                    stroke-linejoin="round">
+                        <path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z">
+                </svg>
+            `;
+
+            [... document.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")].forEach((heading) => {
+                const anchor = document.createElement("a");
+                anchor.style.color = 'inherit';
+                anchor.className = "group relative cursor-pointer";
+                anchor.href = `#${heading.id}`;
+                heading.parentNode!.insertBefore(anchor, heading);
+
+                const linkIconWrapper = document.createElement("div");
+                console.log(heading.scrollHeight, heading.clientHeight, heading.offsetHeight)
+                Object.assign(linkIconWrapper.style, {
+                    width: '15px',
+                    height: '10px',
+                    position: 'absolute',
+                    left: '-24px',
+                    top: ((heading.clientHeight - 15 ) / 2)  + 'px'
+                });
+                heading.prepend (linkIconWrapper);
+                linkIconWrapper.className = "hidden group-hover:block";
+
+                linkIconWrapper.innerHTML = linkSvg;
+                anchor.appendChild(heading);
+            });
+        </script>
     </div>
 </Layout>

--- a/src/layouts/WhatsNewPost.astro
+++ b/src/layouts/WhatsNewPost.astro
@@ -127,24 +127,32 @@ const headings = thisPost?.getHeadings().filter((h) => h.depth < 3) ?? [];
                 </svg>
             `;
 
-            [... document.querySelectorAll<HTMLElement>("h1, h2, h3, h4, h5, h6")].forEach((heading) => {
-                const anchor = document.createElement("a");
+            [
+                ...document.querySelectorAll<HTMLElement>(
+                    'h1, h2, h3, h4, h5, h6'
+                )
+            ].forEach((heading) => {
+                const anchor = document.createElement('a');
                 anchor.style.color = 'inherit';
-                anchor.className = "group relative cursor-pointer";
+                anchor.className = 'group relative cursor-pointer';
                 anchor.href = `#${heading.id}`;
                 heading.parentNode!.insertBefore(anchor, heading);
 
-                const linkIconWrapper = document.createElement("div");
-                console.log(heading.scrollHeight, heading.clientHeight, heading.offsetHeight)
+                const linkIconWrapper = document.createElement('div');
+                console.log(
+                    heading.scrollHeight,
+                    heading.clientHeight,
+                    heading.offsetHeight
+                );
                 Object.assign(linkIconWrapper.style, {
                     width: '15px',
                     height: '10px',
                     position: 'absolute',
                     left: '-24px',
-                    top: ((heading.clientHeight - 15 ) / 2)  + 'px'
+                    top: (heading.clientHeight - 15) / 2 + 'px'
                 });
-                heading.prepend (linkIconWrapper);
-                linkIconWrapper.className = "hidden group-hover:block";
+                heading.prepend(linkIconWrapper);
+                linkIconWrapper.className = 'hidden group-hover:block';
 
                 linkIconWrapper.innerHTML = linkSvg;
                 anchor.appendChild(heading);


### PR DESCRIPTION
Adds clickable headers to the whats-new pages so people can copy them and direct-link to them.